### PR TITLE
Add inventory page with instruction for configuring tokens

### DIFF
--- a/src/pages/controller/inventory.md
+++ b/src/pages/controller/inventory.md
@@ -11,9 +11,10 @@ By default, commonly used tokens are indexed and automatically shown. Full list 
 ```toml
 # torii-config.toml
 
+[indexing]
 contracts = [
-  { type = "ERC20", address = "<contract-address>" },
-  { type = "ERC721", address = "<contract-address>" }
+  "erc20:<contract-address>",
+  "erc721:<contract-address>"
 ]
 ```
 

--- a/src/pages/controller/inventory.md
+++ b/src/pages/controller/inventory.md
@@ -1,0 +1,45 @@
+# Inventory 
+
+Cartridge Controller provides Inventory modal to manage account assets (`ERC-20`, `ERC-721`) tokens.
+
+## Configure tokens
+
+By default, commonly used tokens are indexed and automatically shown. ([default token list](https://github.com/cartridge-gg/controller/packages/torii-config/public-tokens/mainnet.toml)). This list can be extended by configuring Torii hosted on Slot.
+
+### Configure additional token to index
+
+```toml
+# torii-config.toml
+
+contracts = [
+  { type = "ERC20", address = "<contract-address>" },
+  { type = "ERC721", address = "<contract-address>" }
+]
+```
+
+### Create or update Torii instance on Slot
+
+```sh
+slot d create <project> torii --config <path/to/torii-config.toml>
+```
+
+### Configure Controller
+
+Provide Slot project name to `ControllerOptions`.
+
+```typescript
+const controller = new Controller({
+  slot: "<project>" 
+});
+
+// or via connector
+const connector = new CartridgeConnector({
+  slot: "<project>" 
+})
+```
+
+### Open Inventory modal
+
+```typescript
+controller.openProfile("inventory");
+```

--- a/src/pages/controller/inventory.md
+++ b/src/pages/controller/inventory.md
@@ -1,10 +1,10 @@
 # Inventory 
 
-Cartridge Controller provides Inventory modal to manage account assets (`ERC-20`, `ERC-721`) tokens.
+Cartridge Controller provides Inventory modal to manage account assets (`ERC-20`, `ERC-721`).
 
 ## Configure tokens
 
-By default, commonly used tokens are indexed and automatically shown. ([default token list](https://github.com/cartridge-gg/controller/packages/torii-config/public-tokens/mainnet.toml)). This list can be extended by configuring Torii hosted on Slot.
+By default, commonly used tokens are indexed and automatically shown. Full list of default tokens are listed in [`torii-config/public-tokens/mainnet.tom`](https://github.com/cartridge-gg/controller/packages/torii-config/public-tokens/mainnet.toml). This list can be extended by configuring Torii hosted on Slot.
 
 ### Configure additional token to index
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -103,6 +103,10 @@ export default defineConfig({
           ],
         },
         {
+          text: "Inventory",
+          link: "/controller/inventory",
+        },
+        {
           text: "Controller Examples",
           items: [
             {


### PR DESCRIPTION
Ref: https://github.com/cartridge-gg/controller/pull/1068

I'm not confident in writing so happy to adapt to any suggestion @tarrencev 

### Note
ERC20 is currently still uses RPC calls. Until we fully migrate to Torii's `tokenBalances` query, `tokens` option is required in `ControllerOptions`