### PR TITLE
fix(slot): correct command order in scale documentation

### DIFF
--- a/src/pages/slot/scale.md
+++ b/src/pages/slot/scale.md
@@ -49,7 +49,7 @@ To deploy a slot service in multiple regions, you can use the `--regions` flag.
 Katana is only supported in `us-east` at this time.
 
 ```shell
-slot d create --tier insane --regions us-east,asia-southeast,europe-west my-project torii
+slot d create --tier insane my-project torii --regions us-east,asia-southeast,europe-west
 ```
 
 Multi-region deployments are billed based on the number of regions you choose and the tier you are using by multiplying the monthly cost of the tier by the number of regions times replicas. For example, if you have two replicas in three regions, you will be billed six times the monthly cost of the tier you are using.


### PR DESCRIPTION
Rearranged command parameters for proper usage alignment.