### PR TITLE
Update `account_sdk` package url

### DIFF
--- a/src/pages/controller/examples/rust.md
+++ b/src/pages/controller/examples/rust.md
@@ -11,7 +11,7 @@ Add the `account_sdk` crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-account_sdk = { git = "https://github.com/cartridge-gg/controller", package = "account_sdk" }
+account_sdk = { git = "https://github.com/cartridge-gg/controller-rs.git", package = "account_sdk" }
 starknet = "0.10" # Make sure to use a compatible version
 ```
 


### PR DESCRIPTION
Added the correct git url for `account_sdk` package. The git url on the documentation does not work with Rust.

New `account_sdk` package url: https://github.com/cartridge-gg/controller-rs.git