### PR TITLE
docs(slot): update region details and examples

### DIFF
--- a/src/pages/slot/scale.md
+++ b/src/pages/slot/scale.md
@@ -42,21 +42,23 @@ Replicas are billed as how many replicas you have. For example, if you have 3 re
 
 ## Regions
 
-For torii, with premium tiers, you can choose to deploy your instances in multiple regions.
+The default for all regions is us-east, but you can choose to deploy your instances in a different or even multiple regions.
 
 | Region            |
 |-------------------|
 | `us-east`         |
 | `europe-west`     |
-| `asia-southeast`  |
 
 To deploy a slot service in multiple regions, you can use the `--regions` flag.
 
-Katana is only supported in `us-east` at this time.
-
 ```shell
-slot d create --tier pro my-project torii --regions us-east,asia-southeast,europe-west
+# torii supports multiple versions - billed per replica per region
+slot d create --tier pro my-project torii --regions us-east,europe-west
+# or
+slot d create --tier pro my-project katana --regions europe-west
 ```
+
+Katana can be only launched in a single region, while torii uses replicas and routes global users to the nearest one.
 
 Multi-region deployments are billed based on the number of regions you choose and the tier you are using by multiplying the monthly cost of the tier by the number of regions times replicas. For example, if you have two replicas in three regions, you will be billed six times the monthly cost of the tier you are using.
 


### PR DESCRIPTION
Clarified default region as `us-east` and updated deployment examples to align with changes. Highlighted differences between torii and katana services regarding regions and replicas. Enhanced multi-region billing explanation for better understanding.