### PR TITLE
docs(slot): remove transfer command references

### DIFF
--- a/src/pages/slot/getting-started.md
+++ b/src/pages/slot/getting-started.md
@@ -102,7 +102,6 @@ Teams need credits to run services and paymasters. You can fund teams using CLI 
 **CLI:**
 ```sh
 slot auth fund
-slot auth transfer <Team Name> --credits <amount>
 ```
 
 **Web Interface:**

--- a/src/pages/slot/paymaster.md
+++ b/src/pages/slot/paymaster.md
@@ -520,9 +520,8 @@ slot paymaster my-game-pm transactions --filter REVERTED --last 24hr
 # Create team if it doesn't exist
 slot teams my-team create --email developer@mygame.com
 
-# Fund your account and transfer to team
+# Fund a team
 slot auth fund
-slot auth transfer my-team --credit 100
 
 # Create paymaster
 slot paymaster my-game-pm create --team my-team --budget 1000 --unit CREDIT
@@ -555,11 +554,8 @@ If you encounter insufficient credits when creating or funding a paymaster:
 # Check team balance first
 slot teams my-team info
 
-# Fund your account if needed
+# Fund a team
 slot auth fund
-
-# Transfer more credits to team
-slot auth transfer my-team --credit 50
 
 # Retry your paymaster operation
 slot paymaster my-game-pm create --team my-team --budget 1000 --unit CREDIT

--- a/src/pages/slot/scale.md
+++ b/src/pages/slot/scale.md
@@ -70,11 +70,7 @@ If you have existing deployments, a team of the same name as your account will b
 slot teams my-team create --email my-email@example.com # email is required for billing alerts
 slot teams my-team update --email my-email@example.com # if you want to update an existing team's email
 
-slot auth fund # buy credits for your account, this opens the browser
-
-slot auth transfer my-team --usd 10 # transfer $10 from your controller to my-team
-# or
-slot auth transfer my-team --credits 1000 # transfer 1000 credits ($10) from your controller to my-team
+slot auth fund # buy credits for a team, this opens the browser
 ```
 
 Once you create paid slot instances, funds are deducted on a daily basic with a minimum charge of one day. For example, if you create a deployment and delete it after one hour, you will be charged 1/30th of the monthly cost.


### PR DESCRIPTION
Removed outdated `slot auth transfer` command references across multiple files. Updated examples and instructions to reflect current processes for funding teams directly.