### PR TITLE
docs: Update documentation for controller PR #2015

### DIFF
--- a/src/pages/controller/getting-started.mdx
+++ b/src/pages/controller/getting-started.mdx
@@ -184,12 +184,12 @@ export function StarknetProvider({ children }: { children: React.ReactNode }) {
 
 ## Compatibility Guide
 
-The following common dependencies are compatible with the latest version of Cartridge Controller (v0.10.0):
+The following common dependencies are compatible with the latest version of Cartridge Controller (v0.10.2):
 
 ```ts
   "@cartridge/arcade": "0.0.2"
-  "@cartridge/connector": "0.10.0"
-  "@cartridge/controller": "0.10.0"
+  "@cartridge/connector": "0.10.2"
+  "@cartridge/controller": "0.10.2"
   "@cartridge/presets": "0.5.4"
   "@dojoengine/core": "1.7.0-preview.3"
   "@dojoengine/predeployed-connector": "1.7.0-preview.3"


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2015

    **Original PR Details:**
    - Title: Prepare release: 0.10.2
    - Files changed: CHANGELOG.md
examples/next/package.json
examples/node/package.json
examples/svelte/package.json
packages/connector/package.json
packages/controller/package.json
packages/eslint/package.json
packages/keychain/package.json
packages/keychain/src/components/home.tsx
packages/tsconfig/package.json

    Please review the documentation changes to ensure they accurately reflect the controller updates.