### PR TITLE
docs: Update documentation for controller PR #2031

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "validate-twoslash": "node scripts/validate-twoslash.js"
   },
   "dependencies": {
-    "@cartridge/connector": "^0.10.0-alpha.1",
-    "@cartridge/controller": "^0.10.0-alpha.1",
+    "@cartridge/connector": "^0.10.2",
+    "@cartridge/controller": "^0.10.2",
     "@starknet-io/types-js": "^0.8.4",
     "@starknet-react/chains": "^0.1.7",
     "@starknet-react/core": "^3.5.0",

--- a/src/pages/controller/getting-started.mdx
+++ b/src/pages/controller/getting-started.mdx
@@ -184,13 +184,13 @@ export function StarknetProvider({ children }: { children: React.ReactNode }) {
 
 ## Compatibility Guide
 
-The following common dependencies are compatible with the latest version of Cartridge Controller (v0.10.0):
+The following common dependencies are compatible with the latest version of Cartridge Controller (v0.10.2):
 
 ```ts
   "@cartridge/arcade": "0.0.2"
-  "@cartridge/connector": "0.10.0"
-  "@cartridge/controller": "0.10.0"
-  "@cartridge/presets": "0.5.4"
+  "@cartridge/connector": "0.10.2"
+  "@cartridge/controller": "0.10.2"
+  "@cartridge/presets": "github:cartridge-gg/presets#f60358b"
   "@dojoengine/core": "1.7.0-preview.3"
   "@dojoengine/predeployed-connector": "1.7.0-preview.3"
   "@dojoengine/sdk": "1.7.0-preview.3"


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2031

    **Original PR Details:**
    - Title: bump: udpate presets package
    - Files changed: package.json
pnpm-lock.yaml

    Please review the documentation changes to ensure they accurately reflect the controller updates.