### PR TITLE
docs: Update documentation for controller PR #2057

### DIFF
--- a/src/pages/controller/getting-started.mdx
+++ b/src/pages/controller/getting-started.mdx
@@ -188,7 +188,7 @@ The following common dependencies are compatible with the latest version of Cart
 
 :::note
 This ecosystem is evolving rapidly.
-This information is accurate as of September 19, 2025.
+This information is accurate as of September 24, 2025.
 :::
 
 ```ts
@@ -196,11 +196,11 @@ This information is accurate as of September 19, 2025.
   "@cartridge/connector": "0.10.3"
   "@cartridge/controller": "0.10.3"
   "@cartridge/presets": "0.5.4"
-  "@dojoengine/core": "1.7.0-preview.3"
+  "@dojoengine/core": "^1.7.0"
   "@dojoengine/predeployed-connector": "1.7.0-preview.3"
-  "@dojoengine/sdk": "1.7.0-preview.3"
+  "@dojoengine/sdk": "^1.7.2"
   "@dojoengine/torii-client": "1.7.0-preview.3"
-  "@dojoengine/torii-wasm": "1.7.0-preview.3"
+  "@dojoengine/torii-wasm": "^1.7.2"
   "@dojoengine/utils": "1.7.0-preview.3"
   "@starknet-io/types-js": "^0.8.4"
   "@starknet-react/chains": "^5.0.1"


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2057

    **Original PR Details:**
    - Title: chore: bump dojo
    - Files changed: packages/keychain/src/components/connect/create/useCreateController.ts
packages/keychain/src/hooks/collection.ts
packages/keychain/src/hooks/connection.ts
packages/keychain/src/utils/connection/index.ts
packages/keychain/src/utils/connection/switchChain.ts
pnpm-lock.yaml
pnpm-workspace.yaml

    Please review the documentation changes to ensure they accurately reflect the controller updates.