### PR TITLE
docs(slot): add RPC endpoints and usage guide

### DIFF
--- a/src/pages/slot/rpc.md
+++ b/src/pages/slot/rpc.md
@@ -1,0 +1,122 @@
+---
+description: Cartridge RPC endpoints for Starknet mainnet and Sepolia testnet with authentication and CORS configuration.
+title: Cartridge RPC
+---
+
+# Cartridge RPC
+
+Cartridge provides dedicated RPC endpoints for Starknet networks with built-in authentication and CORS support.
+
+## Endpoints
+
+### Mainnet
+```
+https://api.cartridge.gg/x/starknet/mainnet
+```
+
+### Sepolia Testnet
+```
+https://api.cartridge.gg/x/starknet/sepolia
+```
+
+## Authentication
+
+Cartridge RPC supports two authentication methods:
+
+### API Token Authentication
+
+Authenticate requests using an API token with the `Authorization` header:
+
+```bash
+curl https://api.cartridge.gg/x/starknet/mainnet \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "starknet_chainId",
+    "params": [],
+    "id": 1
+  }'
+```
+
+### Domain Whitelisting
+
+For browser-based applications, whitelist your domains to make direct RPC calls without exposing API tokens. Once configured, your whitelisted domains can make requests directly:
+
+```javascript
+const response = await fetch('https://api.cartridge.gg/x/starknet/mainnet', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    jsonrpc: '2.0',
+    method: 'starknet_chainId',
+    params: [],
+    id: 1,
+  }),
+});
+```
+
+:::info
+Requests from whitelisted domains without an API token are rate limited per IP address.
+:::
+
+## Setup with Slot CLI
+
+### Prerequisites
+
+Authenticate with Cartridge:
+
+```bash
+slot auth login
+```
+
+### Managing API Tokens
+
+Create a new RPC API token:
+
+```bash
+slot rpc tokens create <KEY_NAME> --team <TEAM_NAME>
+```
+
+List all RPC API tokens:
+
+```bash
+slot rpc tokens list --team <TEAM_NAME>
+```
+
+Delete an RPC API token:
+
+```bash
+slot rpc tokens delete <KEY_ID> --team <TEAM_NAME>
+```
+
+### Managing CORS Whitelist
+
+Add a domain to the CORS whitelist:
+
+```bash
+slot rpc whitelist add <DOMAIN> --team <TEAM_NAME>
+```
+
+Examples:
+```bash
+# Whitelist a specific domain
+slot rpc whitelist add example.com --team my-team
+
+# Wildcard patterns are supported
+slot rpc whitelist add *.example.com --team my-team
+```
+
+List all whitelisted domains:
+
+```bash
+slot rpc whitelist list --team <TEAM_NAME>
+```
+
+Remove a domain from the CORS whitelist:
+
+```bash
+slot rpc whitelist remove <ENTRY_ID> --team <TEAM_NAME>
+```

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -193,6 +193,10 @@ export default defineConfig({
             text: "vRNG",
             link: "/slot/vrng",
           },
+          {
+            text: "RPC",
+            link: "/slot/rpc",
+          },
         ],
       },
     ],


### PR DESCRIPTION
Added documentation for Cartridge RPC endpoints including mainnet and testnet URLs, authentication methods (API tokens and CORS whitelisting), and setup instructions using the Slot CLI. Provided examples for token and whitelist management commands.