### PR TITLE
docs: Update documentation for controller PR #2106

### DIFF
--- a/src/pages/controller/examples/node.md
+++ b/src/pages/controller/examples/node.md
@@ -49,8 +49,8 @@ async function main() {
 
   // Create a session provider
   const provider = new SessionProvider({
-    rpc: "https://api.cartridge.gg/x/starknet/sepolia",
-    chainId: constants.StarknetChainId.SN_SEPOLIA,
+    rpc: "https://api.cartridge.gg/x/starknet/mainnet",
+    chainId: constants.StarknetChainId.SN_MAIN,
     policies: {
       contracts: {
         [STRK_CONTRACT_ADDRESS]: {

--- a/src/pages/controller/examples/react.md
+++ b/src/pages/controller/examples/react.md
@@ -91,9 +91,9 @@ const provider = jsonRpcProvider({
   rpc: (chain: Chain) => {
     switch (chain) {
       case mainnet:
-        return { nodeUrl: 'https://api.cartridge.gg/x/starknet/mainnet' }
-      case sepolia:
       default:
+        return { nodeUrl: 'https://api.cartridge.gg/x/starknet/mainnet' };
+      case sepolia:
         return { nodeUrl: 'https://api.cartridge.gg/x/starknet/sepolia' }
     }
   },

--- a/src/pages/controller/getting-started.mdx
+++ b/src/pages/controller/getting-started.mdx
@@ -88,7 +88,7 @@ const controller = new Controller({
     { rpcUrl: "https://api.cartridge.gg/x/starknet/sepolia" },
     { rpcUrl: "https://api.cartridge.gg/x/starknet/mainnet" },
   ],
-  defaultChainId: constants.StarknetChainId.SN_SEPOLIA,
+  defaultChainId: constants.StarknetChainId.SN_MAIN,
 });
 ```
 
@@ -124,9 +124,9 @@ const provider = jsonRpcProvider({
   rpc: (chain) => {
     switch (chain) {
       case mainnet:
+      default:
         return { nodeUrl: "https://api.cartridge.gg/x/starknet/mainnet" };
       case sepolia:
-      default:
         return { nodeUrl: "https://api.cartridge.gg/x/starknet/sepolia" };
     }
   },
@@ -136,7 +136,7 @@ const provider = jsonRpcProvider({
 export function StarknetProvider({ children }: { children: React.ReactNode }) {
   return (
     <StarknetConfig
-      defaultChainId={sepolia.id}
+      defaultChainId={mainnet.id}
       chains={[mainnet, sepolia]}
       provider={provider}
       connectors={[controller]}
@@ -193,8 +193,8 @@ const policies: SessionPolicies = {
 
 const sessionConnector = new SessionConnector({
   policies,
-  rpc: "https://api.cartridge.gg/x/starknet/sepolia",
-  chainId: constants.StarknetChainId.SN_SEPOLIA,
+  rpc: "https://api.cartridge.gg/x/starknet/mainnet",
+  chainId: constants.StarknetChainId.SN_MAIN,
   redirectUrl: typeof window !== "undefined" ? window.location.origin : "",
   // Optional: specify keychain URL for custom deployments
   keychainUrl: "https://x.cartridge.gg",


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2106

    **Original PR Details:**
    - Title: Change default chain from Sepolia to mainnet in keychain
    - Files changed: examples/next/src/components/providers/StarknetProvider.tsx
packages/keychain/src/components/connect/create/username/account-search-dropdown.tsx
packages/keychain/src/components/connect/create/username/index.tsx
packages/keychain/src/hooks/connection.ts
packages/keychain/src/hooks/device.ts

    Please review the documentation changes to ensure they accurately reflect the controller updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates docs to use mainnet as the default chain and RPC across Node, React, and Getting Started examples (formerly Sepolia).
> 
> - **Documentation updates (controller)**:
>   - **Defaults moved to mainnet**:
>     - `src/pages/controller/examples/node.md`: `rpc` → `.../mainnet`, `chainId` → `SN_MAIN`.
>     - `src/pages/controller/examples/react.md`: JSON-RPC provider now defaults to `.../mainnet` for unspecified chains.
>     - `src/pages/controller/getting-started.mdx`:
>       - Controller config `defaultChainId` → `SN_MAIN`.
>       - `StarknetProvider` `defaultChainId` → `mainnet.id` and provider defaults mainnet for unspecified chains.
>       - `SessionConnector` example: `rpc` → `.../mainnet`, `chainId` → `SN_MAIN`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adf42cde7d3a66c8a9f2177155f2220863a11ebb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->