### PR TITLE
docs: Update documentation for controller PR #2120

### DIFF
--- a/src/pages/controller/purchasing.md
+++ b/src/pages/controller/purchasing.md
@@ -6,7 +6,7 @@ title: Purchase Integration
 # Purchase Integration
 
 Cartridge Controller provides built-in purchase functionality that enables seamless monetization for games and applications.
-The purchase system supports both traditional payment methods (credit cards) and cryptocurrency transactions across multiple blockchain networks.
+The purchase system supports cryptocurrency transactions across multiple blockchain networks.
 
 ## Overview
 
@@ -17,7 +17,7 @@ The purchase system includes:
 - **Credit Purchases**: Direct credit top-ups for gasless transactions
 - **Multichain Payment Support**: Accept payments on Starknet, Ethereum (Base), Arbitrum, and Optimism with unified payment method selection
 - **Multiple Wallet Integration**: Support for popular wallets across different ecosystems with automatic chain switching for compatible wallets
-- **Unified Payment Interface**: Both fiat (credit card) and crypto payment options displayed on a single screen
+- **Multi-wallet Integration**: Support for popular wallets across different ecosystems with automatic chain switching for compatible wallets
 - **NFT Marketplace Support**: ERC721 and ERC1155 listing and purchase capabilities with integrated client fee structure
 
 ## Quick Start
@@ -226,9 +226,9 @@ enum StarterPackItemType {
 ## Starterpack Types
 
 ### Paid Starterpacks
-Paid starterpacks require purchase and support multiple payment methods (credit card or cryptocurrency).
+Paid starterpacks require purchase and support cryptocurrency payment methods.
 These typically include premium game assets, larger credit bundles, and exclusive items.
-Cross-chain crypto payments are powered by Layerswap, and credit card payments are powered by Stripe.
+Cross-chain crypto payments are powered by Layerswap.
 
 ### Claimable Starterpacks
 Free starterpacks that users can claim based on eligibility criteria. These starterpacks:
@@ -271,8 +271,7 @@ Solana payment functionality is currently disabled and will be re-enabled in a f
 The purchase process follows these steps:
 
 1. **Item Selection**: User selects starterpack or credit amount
-2. **Payment Method & Network Selection**: Choose from all available options on a unified screen:
-   - **Credit Card**: Direct fiat payment via Stripe
+2. **Payment Method & Network Selection**: Choose from available cryptocurrency payment options:
    - **Cryptocurrency**: Pay with Crypto from Ethereum, Base, Arbitrum, or Optimism
 3. **Wallet Connection**: Connect external wallet with automatic chain switching (supported on MetaMask, Rabby, Base, and WalletConnect)
 4. **Cross-Chain Bridging**: Layerswap automatically handles token bridging to Starknet if needed


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2120

    **Original PR Details:**
    - Title: fix: disable cc payment in starterpack
    - Files changed: packages/keychain/src/components/purchasenew/method.tsx

    Please review the documentation changes to ensure they accurately reflect the controller updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates purchasing docs to crypto-only payments, removing credit card references and adjusting flow and starterpack sections accordingly.
> 
> - **Docs (Controller Purchasing Guide)**:
>   - Remove all fiat/credit card references and the unified payment interface, making payments crypto-only across the page (`src/pages/controller/purchasing.md`).
>   - Update purchase flow to show only cryptocurrency method selection; remove Stripe mentions; keep Layerswap cross-chain bridging details.
>   - Revise paid starterpack description to crypto-only; retain Layerswap for cross-chain payments.
>   - Minor wording tweak to wallet integration bullet (multi-wallet phrasing).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26aca74bbb40e1076eb1ec3743a46ddeb3fb00ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->