### PR TITLE
docs: Update documentation for controller PR #2131

### DIFF
--- a/src/pages/controller/configuration.md
+++ b/src/pages/controller/configuration.md
@@ -171,7 +171,7 @@ controller.openPurchaseCredits();
 
 ### openStarterPack(starterpackId: string)
 
-Opens the starterpack purchase interface for a specific bundle.
+Opens the starterpack purchase interface for a specific bundle from the onchain registry.
 
 ```typescript
 controller.openStarterPack("starterpack-id-123");

--- a/src/pages/controller/overview.md
+++ b/src/pages/controller/overview.md
@@ -44,5 +44,5 @@ title: Controller Overview
 ### Monetization and Payments
 
 -   Multi-chain cryptocurrency and fiat support
--   Starterpack bundles combining credits and game assets
+-   Onchain starterpack registry for secure, immutable bundles of credits and game assets
 -   ERC721 and ERC1155 NFT marketplace support with automated fee management


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2131

    **Original PR Details:**
    - Title: Remove custom starterpack support in favor of onchain registry
    - Files changed: examples/next/src/components/Starterpack.tsx
packages/controller/src/controller.ts
packages/controller/src/types.ts
packages/keychain/src/components/purchasenew/starterpack/starter-item.tsx
packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
packages/keychain/src/context/purchase.tsx
packages/keychain/src/hooks/starterpack.ts
packages/keychain/src/utils/__tests__/purchase-display.test.ts
packages/keychain/src/utils/__tests__/starterpack-price.test.ts
packages/keychain/src/utils/__tests__/starterpack-url.test.ts
packages/keychain/src/utils/connection/index.ts
packages/keychain/src/utils/payments.ts
packages/keychain/src/utils/starterpack-url.ts
packages/keychain/src/utils/starterpack.ts

    Please review the documentation changes to ensure they accurately reflect the controller updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rewrites Controller purchasing docs to require onchain starterpack IDs, removes custom StarterPack configuration, and updates references and examples across pages.
> 
> - **Purchasing / API**:
>   - Change `openStarterPack` signature to `openStarterPack(starterpackId: string)` and remove support for custom `StarterPack` objects.
>   - Delete examples/imports using `StarterPack` and custom pack construction; keep `StarterPackItem` and `StarterPackItemType` only for UI rendering.
>   - Add **Onchain Starterpack Registry** section with breaking-change notice and migration guidance.
> - **Configuration**:
>   - Update `openStarterPack` description to reference bundles from the onchain registry.
> - **Overview**:
>   - Replace monetization bullet with emphasis on an onchain starterpack registry for immutable bundles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0805384db5acb4dad1a5c409ffdeca54ee9b886e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->