### PR TITLE
docs(slot): add documentation for viewing RPC logs

### DIFF
--- a/src/pages/slot/rpc.md
+++ b/src/pages/slot/rpc.md
@@ -127,3 +127,30 @@ Remove a domain from the CORS whitelist:
 ```bash
 slot rpc whitelist remove <ENTRY_ID> --team <TEAM_NAME>
 ```
+
+### Viewing RPC Logs
+
+View RPC request logs for your team:
+
+```bash
+slot rpc logs --team <TEAM_NAME>
+```
+
+#### Options
+
+- `--after <CURSOR>`: Fetch logs after a specific cursor for pagination
+- `--limit <NUMBER>`: Limit the number of log entries returned (default: 100)
+- `--since <DURATION>`: Fetch logs from a specific time period (e.g., `30m`, `1h`, `24h`)
+
+#### Examples
+
+```bash
+# View the last 5 log entries from the past 30 minutes
+slot rpc logs --team my-team --limit 5 --since 30m
+
+# Paginate through logs using a cursor
+slot rpc logs --team my-team --after gaFpuWNtaDVhZ3k2Nzc2c2gwMWR4N3FsYXlhc2s --limit 5
+
+# View recent logs with time filter
+slot rpc logs --team my-team --since 1h
+```


### PR DESCRIPTION
Add section detailing usage of the `slot rpc logs` command, including options and examples for filtering and paginating RPC request logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a new "Viewing RPC Logs" section to `src/pages/slot/rpc.md` documenting `slot rpc logs` usage, options (`--after`, `--limit`, `--since`), and examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b951679399a884bcf674f37647746fefbeac924. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->