### PR TITLE
Add Billing docs for Slot teams; update navigation

### DIFF
--- a/src/pages/slot/billing.md
+++ b/src/pages/slot/billing.md
@@ -1,0 +1,191 @@
+---
+description: Learn how to manage billing for Slot services through team-based credit management.
+title: Billing
+---
+
+# Billing
+
+All billing in Slot is managed through teams. Teams are the billing entity that owns credits, which are used to pay for deployments, paymasters, RPC requests, and other Slot services.
+
+## Overview
+
+Slot uses a prepaid credit system where:
+- All costs are charged to a **team's credit balance**
+- Teams can be funded via credit card or cryptocurrency
+- Credits are deducted automatically as you use services
+- You can monitor spending through invoices and team balance
+
+## Setting Up Billing
+
+### 1. Create a Team
+
+First, create a team with an email address for billing notifications:
+
+```sh
+slot teams <team-name> create --email <your-email@example.com>
+```
+
+**Example:**
+```sh
+slot teams my-game create --email developer@mygame.com
+```
+
+:::info
+If you create a deployment before creating a team explicitly, a team with the same name as your project will be created automatically.
+:::
+
+### 2. Fund Your Team
+
+To add credits to your team, use the `slot auth fund` command which opens a browser interface:
+
+```sh
+slot auth fund
+```
+
+This will:
+1. Open your browser to the funding interface
+2. Display a list of your teams
+3. Allow you to select the team you want to fund
+4. Provide payment options (credit card or crypto)
+5. Complete the purchase and add credits to the selected team
+
+**Web Interface:**
+You can also navigate directly to `https://x.cartridge.gg/slot/fund` to fund teams through the web interface.
+
+## Managing Teams
+
+### Update Team Email
+
+Update the billing email for an existing team:
+
+```sh
+slot teams <team-name> update --email <new-email@example.com>
+```
+
+### Check Team Balance
+
+View your team's current credit balance and information:
+
+```sh
+slot teams <team-name> info
+```
+
+### View Invoices
+
+Check billing history and invoices for your team:
+
+```sh
+slot teams <team-name> invoices
+```
+
+This command displays:
+- Past billing periods
+- Credits consumed
+- Services used
+- Total charges
+
+### Team Collaborators
+
+Add or remove team members who can manage the team's resources:
+
+```sh
+# List current team members
+slot teams <team-name> list
+
+# Add a collaborator
+slot teams <team-name> add <username>
+
+# Remove a collaborator
+slot teams <team-name> remove <username>
+```
+
+:::info
+The username is the Cartridge Controller username used to login.
+:::
+
+## What Uses Credits?
+
+Credits are consumed by various Slot services:
+
+### Deployments
+- **Basic tier**: $10/month (first 3 are free)
+- **Pro tier**: $50/month (2 vCPU, 4GB RAM)
+- **Epic tier**: $100/month (4 vCPU, 8GB RAM)
+- **Legendary tier**: $200/month (8 vCPU, 16GB RAM)
+- **Storage**: $0.20/GB/month (auto-scaling for premium tiers)
+- Billed daily with minimum 1-day charge
+
+### Paymasters
+- Transaction fees are deducted from the paymaster's budget
+- Paymaster budgets are funded from team credits
+- 1 CREDIT = $0.01 USD
+
+### RPC Requests
+- Free tier: 1M requests/month
+- Additional requests: $5 per 1M requests
+- Charged to the team associated with your RPC endpoint
+
+### Multi-Region Deployments
+- Cost multiplied by number of regions × replicas
+- Example: 2 replicas in 3 regions = 6× base tier cost
+
+## Billing Cycle
+
+Slot uses a **daily billing model**:
+- Charges are calculated and deducted daily
+- Minimum charge period is 1 day
+- If you delete a resource after 1 hour, you're still charged for the full day
+- Credits are deducted automatically from your team balance
+
+## Best Practices
+
+### Monitor Your Spending
+- Regularly check `slot teams <team-name> info` to view credit balance
+- Review invoices monthly with `slot teams <team-name> invoices`
+- Set up email notifications by ensuring your team has a valid email
+
+### Keep Sufficient Balance
+- Maintain adequate credits to avoid service interruptions
+- Premium tier deployments (Pro and above) remain active as long as the team has credits
+- Basic tier deployments are auto-scaled down after inactivity but won't be deleted if funded
+
+### Team Organization
+- Use separate teams for different projects or environments
+- Add billing email to receive low-balance alerts
+- Limit team membership to necessary collaborators
+
+## Troubleshooting
+
+### Insufficient Credits Error
+
+If you encounter insufficient credits when creating services:
+
+```sh
+# Check your team's current balance
+slot teams <team-name> info
+
+# Fund the team
+slot auth fund
+
+# Retry your operation
+```
+
+### Service Not Starting
+
+If a premium tier deployment isn't starting:
+- Verify team has sufficient credits with `slot teams <team-name> info`
+- Ensure the service was created with `--team <team-name>` flag
+- Check that you're a member of the team
+
+### Invoice Questions
+
+For billing inquiries or invoice details:
+- Review `slot teams <team-name> invoices` for detailed history
+- Contact support through Discord if you have questions about charges
+- Ensure your team email is up-to-date for billing communications
+
+## Related Documentation
+
+- [Scale](/slot/scale) - Learn about deployment tiers and pricing
+- [Paymaster](/slot/paymaster) - Manage paymaster budgets and policies
+- [RPC](/slot/rpc) - Understand RPC pricing and free tiers

--- a/src/pages/slot/getting-started.md
+++ b/src/pages/slot/getting-started.md
@@ -95,14 +95,6 @@ slot teams <Team Name> remove <Account Name>
 The account name can also be called controller username. The one used to login on controller.
 :::
 
-### Fund teams
+## Billing
 
-Teams need credits to run services and paymasters. You can fund teams using CLI commands or the web interface:
-
-**CLI:**
-```sh
-slot auth fund
-```
-
-**Web Interface:**
-Navigate to `https://x.cartridge.gg/slot/fund` to fund teams through a user-friendly interface with credit card or crypto payments.
+Teams need credits to run paid services and paymasters. See the [Billing](/slot/billing) documentation for information on funding teams and managing credits.

--- a/src/pages/slot/paymaster.md
+++ b/src/pages/slot/paymaster.md
@@ -33,26 +33,7 @@ slot auth login
 
 ## Team Setup
 
-Before creating a paymaster, you need a team with sufficient credits.
-
-### Create a Team (if it doesn't exist)
-
-```sh
-slot teams <team-name> create --email <your-email@example.com>
-```
-
-### Fund Your Account and Transfer to Team
-
-Paymasters automatically deduct from your team's account balance when created. If you don't have sufficient credits:
-
-```sh
-# Buy credits for your account (opens browser)
-slot auth fund
-```
-
-1. Select the team you want to fund from the list
-2. Choose your payment method (credit card or crypto)
-3. Complete the purchase
+Before creating a paymaster, you need a team with sufficient credits. See the [Billing](/slot/billing) documentation for detailed information on setting up teams and funding.
 
 ## Creating a Paymaster
 
@@ -554,13 +535,8 @@ slot paymaster my-game-pm transactions --filter REVERTED --last 24hr
 
 ### Setting up a new game paymaster
 ```sh
-# Create team if it doesn't exist
-slot teams my-team create --email developer@mygame.com
-
-# Fund a team
-slot auth fund
-
-# Create paymaster
+# Set up billing first (see /slot/billing for details)
+# Then create paymaster
 slot paymaster my-game-pm create --team my-team --budget 1000 --unit CREDIT
 
 # Add game contract policies
@@ -585,15 +561,4 @@ slot paymaster my-game-pm budget increase --amount 500 --unit CREDIT
 ```
 
 ### Insufficient Credits Error
-If you encounter insufficient credits when creating or funding a paymaster:
-
-```sh
-# Check team balance first
-slot teams my-team info
-
-# Fund a team
-slot auth fund
-
-# Retry your paymaster operation
-slot paymaster my-game-pm create --team my-team --budget 1000 --unit CREDIT
-```
+If you encounter insufficient credits when creating or funding a paymaster, see the [Billing](/slot/billing) documentation for information on funding your team.

--- a/src/pages/slot/scale.md
+++ b/src/pages/slot/scale.md
@@ -60,20 +60,9 @@ Katana can be only launched in a single region, while torii uses replicas and ro
 
 Multi-region deployments are billed based on the number of regions you choose and the tier you are using by multiplying the monthly cost of the tier by the number of regions times replicas. For example, if you have two replicas in three regions, you will be billed six times the monthly cost of the tier you are using.
 
-## Set up billing
+## Billing
 
-To set up slot billing, you need to buy credits and transfer them to a slot team.
-
-If you have existing deployments, a team of the same name as your account will be created for you, and you can transfer credits to it.
-
-```shell
-slot teams my-team create --email my-email@example.com # email is required for billing alerts
-slot teams my-team update --email my-email@example.com # if you want to update an existing team's email
-
-slot auth fund # buy credits for a team, this opens the browser
-```
-
-Once you create paid slot instances, funds are deducted on a daily basic with a minimum charge of one day. For example, if you create a deployment and delete it after one hour, you will be charged 1/30th of the monthly cost.
+Before creating paid tier deployments, you need to set up billing for your team. See the [Billing](/slot/billing) documentation for detailed information on creating teams, funding, and managing credits.
 
 ## Create an instance with a paid tier
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -187,6 +187,10 @@ export default defineConfig({
             link: "/slot/getting-started",
           },
           {
+            text: "Billing",
+            link: "/slot/billing",
+          },
+          {
             text: "Scale",
             link: "/slot/scale",
           },


### PR DESCRIPTION
## Summary
- Adds a new Billing page detailing Slot teams and prepaid credits.
- Replaces scattered funding guidance with centralized Billing guidance.
- Updates cross-links from Getting Started and Scale to point to the Billing page.
- Updates navigation to surface Billing under Slot docs.

## Changes
### Documentation
- src/pages/slot/billing.md: New comprehensive Billing page covering: overview, setting up billing, managing teams, what uses credits, billing cycle, best practices, troubleshooting, and related docs.
- src/pages/slot/getting-started.md: Replaces in-page funding steps with a reference to Billing; directs users to the Billing page for team funding and credit management.
- src/pages/slot/paymaster.md: Removes in-page funding/setup steps; instructs users to consult Billing for setup and funding details.
- src/pages/slot/scale.md: Replaces inline billing setup content with a pointer to Billing for detailed billing guidance.
- vocs.config.ts: Adds a Billing entry to the Slot navigation for easier access.

### Navigation
- Billing now appears in the Slot docs navigation as a dedicated page.

## Why
- To create a single, authoritative source of truth for Slot billing and team-based credits, ensuring consistency across deployments, paymasters, RPC usage, and multi-region deployments.

## How to test
- Build and view the docs, confirm /slot/billing loads and contains all sections listed in the new page.
- Verify that /slot/getting-started and /slot/scale contain references to the Billing page and link to it.
- Check the Slot navigation to confirm a Billing entry appears under the Slot section.

## Notes
- This is a docs-only change with no impact to runtime behavior or APIs. Check for broken links if migrating references within existing content.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ef451c1b-88a9-4b02-b4d5-9b46c9e69548

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new Slot Billing page and updates getting-started, paymaster, and scale docs to reference it; adds Billing to the Slot sidebar.
> 
> - **Documentation**:
>   - **New Page**: `src/pages/slot/billing.md` covering team-based credits, setup, management, usage, billing cycle, best practices, troubleshooting, and related links.
>   - **Cross-links**: Replace inline funding/setup sections with references to `Billing` in `src/pages/slot/getting-started.md`, `src/pages/slot/paymaster.md`, and `src/pages/slot/scale.md`.
> - **Navigation**:
>   - Add `Billing` to Slot sidebar in `vocs.config.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d5592ee9363083d1908797f8fd7ecbb3f082aa9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->