### PR TITLE
docs: Update documentation for controller PR #2146

### DIFF
--- a/src/pages/controller/examples/telegram.md
+++ b/src/pages/controller/examples/telegram.md
@@ -45,7 +45,7 @@ export const SESSION_POLICIES = {
   },
 };
 
-export const REDIRECT_URI = "https://t.me/hitthingbot/hitthing";
+export const REDIRECT_URI = "https://t.me/hitthingbot/hitthing"; // Optional - can be omitted for in-app completion
 ```
 
 ### 2. Create the SessionProvider:
@@ -62,7 +62,7 @@ const connector = new SessionConnector({
   policies: SESSION_POLICIES,
   rpc: RPC_URL,
   chainId: constants.StarknetChainId.SN_MAINNET,
-  redirectUrl: REDIRECT_URI,
+  redirectUrl: REDIRECT_URI, // Optional - omit for in-app session completion
 });
 
 const provider = jsonRpcProvider({

--- a/src/pages/controller/native-integration.md
+++ b/src/pages/controller/native-integration.md
@@ -133,6 +133,7 @@ DiplomatSessionPolicies_add_contract_policy(
     policy);
 
 // Link the session to the Controller account via the browser
+// Note: redirect_uri is optional - if omitted, session completes in-app
 printf("\nPlease open a browser to this URL and create a session:\n"
         "%s/session"
         "?public_key=%.*s"

--- a/src/pages/controller/sessions.md
+++ b/src/pages/controller/sessions.md
@@ -83,10 +83,33 @@ export type SessionOptions = {
   rpc: string;                      // RPC endpoint URL
   chainId: string;                  // Chain ID for the session
   policies: SessionPolicies;        // Approved transaction policies
-  redirectUrl: string;              // URL to redirect after registration
+  redirectUrl?: string;             // Optional URL to redirect after registration
   disconnectRedirectUrl?: string;   // Optional URL to redirect after disconnect/logout
 };
 ```
+
+## Session Registration Flow
+
+Session registration can work in two modes:
+
+### In-App Registration (No Redirects)
+
+When no `redirectUrl` or callback parameters are provided, sessions complete entirely within the Cartridge interface:
+
+- Users see the session approval screen
+- After approval, they see a success message: "Return to the game to continue"  
+- No external redirects occur
+- Ideal for web applications that can poll for session status
+
+### External Callback Registration
+
+When callback or redirect parameters are provided, sessions can integrate with external applications:
+
+- `callback_uri` - POST session data to a webhook endpoint after approval
+- `redirect_uri` - Redirect browser to external URL with session data as query parameter  
+- `redirectUrl` - Configure default redirect destination
+
+**Security Note**: Callback URLs are strictly validated and must be on an allowlist of approved hostnames and paths for security.
 
 ## Defining Policies
 


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2146

    **Original PR Details:**
    - Title: Allow session registration without callback
    - Files changed: packages/keychain/src/components/session.tsx

    Please review the documentation changes to ensure they accurately reflect the controller updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Document optional redirect/callback parameters and add session registration flow, updating examples and native integration notes accordingly.
> 
> - **Sessions Docs**:
>   - Make `SessionOptions.redirectUrl` optional in `src/pages/controller/sessions.md`.
>   - Add “Session Registration Flow” detailing in-app registration (no redirects) and external callbacks (`callback_uri`, `redirect_uri`, `redirectUrl`) with security note.
> - **Examples**:
>   - Telegram example marks `REDIRECT_URI` and `redirectUrl` as optional for in-app session completion.
> - **Native Integration**:
>   - Add note that `redirect_uri` is optional in session-linking URL, enabling in-app completion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ae62f82fda03020a20c60c6fb54cd79b88ed2fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->