### PR TITLE
docs: Update documentation for controller PR #2157

### DIFF
--- a/src/pages/controller/getting-started.mdx
+++ b/src/pages/controller/getting-started.mdx
@@ -94,6 +94,41 @@ const controller = new Controller({
 });
 ```
 
+## Standalone Authentication
+
+The Controller provides an `open()` method for standalone authentication, which opens the keychain in first-party context. This is useful for establishing first-party storage and enabling seamless iframe access across all games.
+
+```ts
+import Controller from "@cartridge/controller";
+
+const controller = new Controller();
+
+// Basic usage - redirect to current page after authentication
+controller.open();
+
+// With custom redirect URL
+controller.open({
+  redirectUrl: "https://mygame.com/dashboard",
+});
+
+// With preset theme and redirect
+controller.open({
+  redirectUrl: "https://mygame.com/play",
+  preset: "mygame",
+});
+```
+
+### Parameters
+
+The `open()` method accepts an options object with the following properties:
+
+- `redirectUrl?: string` - The URL to redirect to after authentication (defaults to current page)
+- `preset?: string` - The preset theme to use for the keychain interface
+
+:::info
+When using presets, make sure your preset is configured in the [@cartridge/presets](https://github.com/cartridge-gg/presets) repository. See the [presets guide](/controller/presets.md) for more information.
+:::
+
 ## Connectors
 
 Connectors provide standardized integrations of Controller into various types of applications.


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2157

    **Original PR Details:**
    - Title: refactor: separate config loading from verification logic
    - Files changed: examples/next/src/components/providers/StarknetProvider.tsx
packages/controller/src/controller.ts
packages/controller/src/iframe/keychain.ts
packages/keychain/src/components/ConnectRoute.test.tsx
packages/keychain/src/components/ConnectRoute.tsx
packages/keychain/src/components/app.tsx
packages/keychain/src/components/connect/StandaloneConnect.test.tsx
packages/keychain/src/components/connect/StandaloneConnect.tsx
packages/keychain/src/components/connect/create/useCreateController.ts
packages/keychain/src/components/connect/index.tsx
packages/keychain/src/components/purchasenew/claim/claim.tsx
packages/keychain/src/context/purchase.tsx
packages/keychain/src/hooks/connection.test.ts
packages/keychain/src/hooks/connection.ts
packages/keychain/src/hooks/starterpack-onchain.ts
packages/keychain/src/utils/referral.test.ts
packages/keychain/src/utils/referral.ts

    Please review the documentation changes to ensure they accurately reflect the controller updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new "Standalone Authentication" section documenting `controller.open()` usage with `redirectUrl` and `preset` options.
> 
> - **Docs (Getting Started)** in `src/pages/controller/getting-started.mdx`:
>   - **Standalone Authentication**: New section documenting `Controller#open()` for first-party auth.
>     - Usage examples: default redirect, custom `redirectUrl`, and themed `preset`.
>     - Parameters documented: `redirectUrl?: string`, `preset?: string`.
>     - Notes on preset configuration and link to presets guide.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 519432df1b0ed192a6eb8bf7ee855741f55b6bdf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->