### PR TITLE
docs: Update documentation for controller PR #2107

### DIFF
--- a/src/pages/controller/presets.md
+++ b/src/pages/controller/presets.md
@@ -49,6 +49,24 @@ For an example, see [dope-wars](https://github.com/cartridge-gg/presets/blob/mai
                 "entrypoint": "request_random"
               }
             ]
+          },
+          "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7": {
+            "name": "Ethereum Token",
+            "description": "ETH token contract for approvals and transfers",
+            "methods": [
+              {
+                "name": "Approve Spending",
+                "description": "Allow contract to spend ETH tokens",
+                "entrypoint": "approve",
+                "spender": "0x1234567890abcdef1234567890abcdef12345678",
+                "amount": "0x1774160BC6690000"
+              },
+              {
+                "name": "Transfer",
+                "description": "Transfer ETH tokens",
+                "entrypoint": "transfer"
+              }
+            ]
           }
         }
       }
@@ -115,6 +133,71 @@ When a transaction is submitted:
 3. The transaction will only be sponsored if the predicate function returns a truthy value
 
 This allows for sophisticated gas sponsorship policies based on game state, user eligibility, or other conditional logic.
+
+## Token Approval Policies
+
+Starting with controller-wasm 0.3.12+, token approval methods require explicit `spender` and `amount` fields to create an `ApprovalPolicy`. This provides enhanced security and a better user experience with spending limits.
+
+### ApprovalPolicy Configuration
+
+When configuring approve methods in your preset, include both `spender` and `amount` fields:
+
+```json
+{
+  "origin": "mygame.example.com",
+  "chains": {
+    "SN_MAIN": {
+      "policies": {
+        "contracts": {
+          "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7": {
+            "name": "Ethereum Token",
+            "description": "ETH token for game transactions",
+            "methods": [
+              {
+                "name": "Approve Game Contract",
+                "description": "Allow game contract to spend ETH for in-game purchases",
+                "entrypoint": "approve",
+                "spender": "0x1234567890abcdef1234567890abcdef12345678",
+                "amount": "0x1774160BC6690000"
+              },
+              {
+                "name": "Transfer",
+                "description": "Transfer ETH tokens",
+                "entrypoint": "transfer"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Migration from Legacy Approve Methods
+
+If you have existing approve methods without `spender` and `amount` fields, they will continue to work but show a deprecation warning. Update them to the new format:
+
+```json
+// ❌ Legacy format (will show deprecation warning)
+{
+  "name": "Approve",
+  "entrypoint": "approve"
+}
+
+// ✅ New format (creates ApprovalPolicy)
+{
+  "name": "Approve Spending",
+  "entrypoint": "approve",
+  "spender": "0x1234567890abcdef...",
+  "amount": "0x1774160BC6690000"
+}
+```
+
+**Key Benefits:**
+- **Enhanced Security**: Explicit spender and amount limits
+- **Better UX**: Users see spending limits in a dedicated UI
+- **Future-Proof**: Prepares for stricter validation in future versions
 
 ## Apple App Site Association
 

--- a/src/pages/controller/sessions.md
+++ b/src/pages/controller/sessions.md
@@ -110,6 +110,8 @@ type ContractMethod = {
   name: string;                         // Method name
   entrypoint: string;                   // Contract method entrypoint
   description?: string;                 // Optional method description
+  spender?: string;                     // For approve methods: address that can spend tokens
+  amount?: string | number;             // For approve methods: amount that can be spent
 };
 
 type SignMessagePolicy = TypedDataPolicy & {
@@ -209,30 +211,57 @@ const policies: SessionPolicies = {
     // Include other contracts as needed
   }
 };
-<<<<<<< HEAD
+```
 
-// Using the controller directly
-const controller = new Controller({
-  policies,
-  // other options
-});
+#### Token Approval Policies
 
-// Using starknet-react connector
-const connector = new CartridgeConnector({
-  policies,
-  // other options
-});
+For token approval methods, you must specify both `spender` and `amount` fields to create an `ApprovalPolicy`. This provides enhanced security and user experience with spending limits.
 
-// Using SessionConnector with disconnect redirect
-const session = new SessionConnector({
-  policies,
-  rpc: "https://starknet-mainnet.public.blastapi.io/rpc/v0.7",
-  chainId: "SN_MAIN",
-  redirectUrl: "https://myapp.com/",
-  disconnectRedirectUrl: "https://myapp.com/logout-complete", // Optional: redirect after logout
-});
-=======
->>>>>>> 53108ce (fix: clean up sessions.md)
+```typescript
+const policies: SessionPolicies = {
+  contracts: {
+    "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7": {
+      name: "Ethereum",
+      description: "ETH token contract",
+      methods: [
+        {
+          name: "Approve Spending",
+          description: "Allow contract to spend ETH tokens",
+          entrypoint: "approve",
+          spender: "0x1234567890abcdef...",     // Contract that can spend tokens
+          amount: "0x1774160BC6690000"          // Maximum amount (in wei)
+        },
+        {
+          name: "Transfer",
+          description: "Transfer ETH tokens",
+          entrypoint: "transfer"
+        }
+      ]
+    }
+  }
+};
+```
+
+**Important**: When using approve methods, always specify both `spender` and `amount` fields. Legacy approve methods without these fields will fall back to `CallPolicy` and show a deprecation warning.
+
+**Migration from Legacy Approve Methods**
+
+If you have existing approve methods without `spender` and `amount` fields, update them to use the new format:
+
+```typescript
+// ❌ Legacy format (deprecated)
+{
+  name: "Approve",
+  entrypoint: "approve"
+}
+
+// ✅ New format (recommended)
+{
+  name: "Approve Spending",
+  entrypoint: "approve",
+  spender: "0x1234567890abcdef...",  // Contract that can spend tokens
+  amount: "0x1774160BC6690000"       // Maximum spending amount
+}
 ```
 
 #### Signed Message Policies


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2107

    **Original PR Details:**
    - Title: feat: add ApprovalPolicy support for account-wasm 0.3.12
    - Files changed: examples/next/src/components/providers/StarknetProvider.tsx
packages/keychain/src/components/ConnectRoute.test.tsx
packages/keychain/src/components/ConnectRoute.tsx
packages/keychain/src/components/connect/CreateSession.tsx
packages/keychain/src/components/connect/SpendingLimitCard.tsx
packages/keychain/src/components/connect/SpendingLimitPage.tsx
packages/keychain/src/components/connect/create/useCreateController.ts
packages/keychain/src/components/connect/token-consent.tsx
packages/keychain/src/components/purchasenew/claim/claim.tsx
packages/keychain/src/components/session/AggregateCard.tsx
packages/keychain/src/components/session/ContractCard.tsx
packages/keychain/src/components/session/UnverifiedSessionSummary.tsx
packages/keychain/src/components/session/VerifiedSessionSummary.tsx
packages/keychain/src/context/session.tsx
packages/keychain/src/hooks/session.ts
pnpm-lock.yaml
pnpm-workspace.yaml

    Please review the documentation changes to ensure they accurately reflect the controller updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Document ApprovalPolicy-based token approvals with `spender`/`amount`, update types and examples, and add migration guidance.
> 
> - **Docs (Controller)**:
>   - **Token Approval Policies (ApprovalPolicy)**:
>     - Introduce requirement to specify `spender` and `amount` for `approve` methods (controller-wasm 0.3.12+).
>     - Add ETH token contract examples in `presets.md` and `sessions.md` showing `approve` with spending limits.
>     - Update type definitions to include `spender` and `amount` in `ContractMethod`.
>     - Provide migration guidance from legacy approve methods and note deprecation behavior.
>   - **Verified Sessions Presets**:
>     - Extend sample preset to include ETH token approvals alongside transfers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20b3ba57098fc387e65e72fcd2962801164a087d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->