### PR TITLE
docs: Update documentation for controller PR #2192

### DIFF
--- a/src/pages/controller/getting-started.mdx
+++ b/src/pages/controller/getting-started.mdx
@@ -335,3 +335,4 @@ Cartridge Controller in your preferred environment.
 - Customize your [Controller](/controller/presets.md)
 - Set up [Usernames](/controller/usernames.md)
 - Configure [Paymaster](/controller/configuration.md)
+- Explore [Standalone Authentication](/controller/configuration.md#standalone-authentication-flow) for first-party storage access


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2192

    **Original PR Details:**
    - Title: feat: add controller_redirect for standalone flow
    - Files changed: packages/controller/src/controller.ts
packages/keychain/src/hooks/connection.test.ts
packages/keychain/src/hooks/connection.ts
packages/keychain/src/utils/api/generated.ts

    Please review the documentation changes to ensure they accurately reflect the controller updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents standalone authentication flow (controller.open, controller_redirect, storage access check) and links it from Getting Started.
> 
> - **Controller Docs (`src/pages/controller/configuration.md`)**:
>   - Add **Standalone Authentication Flow** section:
>     - `controller.open(options)` with optional `redirectUrl`.
>     - Automatic redirect via `controller_redirect` query param, preserving config and URL state.
>     - Storage access verification via `controller.hasFirstPartyAccess()`.
> - **Getting Started (`src/pages/controller/getting-started.mdx`)**:
>   - Add Next Steps link to Standalone Authentication section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abf2fcbca9182e91d70fb162b8f4ccb26722cf05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->