### PR TITLE
docs: Update documentation for controller PR #2194

### DIFF
--- a/src/pages/controller/starter-packs.md
+++ b/src/pages/controller/starter-packs.md
@@ -271,7 +271,6 @@ If a wallet doesn't support chain switching, users can manually switch chains wi
 Cryptocurrency payments include several fee components:
 
 - **Base Cost**: The actual purchase amount (starterpack or credit value)
-- **Cartridge Processing Fee**: 2.5% service fee
 - **Layerswap Bridging Fee**: Variable fee based on source network and token (typically 0.1-0.5%)
 - **Network Gas Fees**: Standard blockchain transaction fees (paid separately by user)
 


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2194

    **Original PR Details:**
    - Title: refactor: deprecate backend starterpack purchase and add Layerswap deposit support
    - Files changed: packages/keychain/src/components/purchase/CostBreakdown.tsx
packages/keychain/src/components/purchase/CryptoCheckout.stories.tsx
packages/keychain/src/components/purchase/CryptoCheckout.tsx
packages/keychain/src/components/purchase/index.tsx
packages/keychain/src/components/purchasenew/checkout/crypto/index.tsx
packages/keychain/src/components/purchasenew/pending.stories.tsx
packages/keychain/src/components/purchasenew/pending.tsx
packages/keychain/src/context/purchase.tsx
packages/keychain/src/hooks/payments/crypto.ts
packages/keychain/src/utils/api/generated.ts
packages/keychain/src/utils/payments.ts

    Please review the documentation changes to ensure they accurately reflect the controller updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the 2.5% Cartridge processing fee from the cryptocurrency fee breakdown in `src/pages/controller/starter-packs.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5d2f92fd805cfbfa446e333ff8e26f9cfd8c33d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->