### PR TITLE
docs: Update documentation for controller PR #2202

### DIFF
--- a/src/pages/controller/configuration.md
+++ b/src/pages/controller/configuration.md
@@ -29,6 +29,7 @@ export type ControllerOptions = {
     // Keychain options
     url?: string;  // The URL of keychain
     origin?: string;  // The origin of keychain
+    controller_redirect?: string;  // Redirect URL for standalone flow with preset support
     starterPackId?: string;  // The ID of the starter pack to use
     feeSource?: FeeSource;  // The fee source to use for execute from outside
     signupOptions?: AuthOptions;  // Signup options (order reflects UI. Group socials and wallets together)

--- a/src/pages/controller/getting-started.mdx
+++ b/src/pages/controller/getting-started.mdx
@@ -205,17 +205,17 @@ const sessionConnector = new SessionConnector({
 
 ## Compatibility Guide
 
-The following common dependencies are compatible with the latest version of Cartridge Controller (v0.10.3):
+The following common dependencies are compatible with the latest version of Cartridge Controller (v0.11.0):
 
 :::note
 This ecosystem is evolving rapidly.
-This information is accurate as of September 24, 2025.
+This information is accurate as of November 10, 2025.
 :::
 
 ```ts
   "@cartridge/arcade": "0.0.2"
-  "@cartridge/connector": "0.10.3"
-  "@cartridge/controller": "0.10.3"
+  "@cartridge/connector": "0.11.0"
+  "@cartridge/controller": "0.11.0"
   "@cartridge/presets": "0.5.4"
   "@dojoengine/core": "^1.7.0"
   "@dojoengine/predeployed-connector": "1.7.0-preview.3"

--- a/src/pages/controller/starter-packs.md
+++ b/src/pages/controller/starter-packs.md
@@ -204,6 +204,11 @@ Paid starterpacks require purchase and support multiple payment methods (credit 
 These typically include premium game assets, larger credit bundles, and exclusive items.
 Cross-chain crypto payments are powered by Layerswap, and credit card payments are powered by Stripe.
 
+As of v0.11.0, starterpack purchases now use **Layerswap deposit support**, replacing the previous backend purchase flow with a more flexible deposit-based approach. This enables:
+- More reliable cross-chain bridging
+- Better transaction transparency with hash display
+- Simplified purchase flow integration
+
 ### Claimable Starterpacks
 Free starterpacks that users can claim based on eligibility criteria. These starterpacks:
 - **No payment required**: Users can claim them for free
@@ -250,8 +255,8 @@ The purchase process follows these steps:
    - **Cryptocurrency**: Pay with Crypto from Ethereum, Base, Arbitrum, or Optimism
 3. **Wallet Connection**: Connect external wallet with automatic chain switching (supported on MetaMask, Rabby, Base, and WalletConnect)
 4. **Cross-Chain Bridging**: Layerswap automatically handles token bridging to Starknet if needed
-5. **Transaction Processing**: Complete payment through selected method with automatic bridging fees calculation
-6. **Confirmation**: Receive purchase confirmation and assets in your Cartridge account
+5. **Transaction Processing**: Complete payment through selected method with automatic bridging fees calculation  
+6. **Confirmation**: Receive purchase confirmation with transaction hash display and assets in your Cartridge account
 
 ## Cross-Chain Bridging with Layerswap
 


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2202

    **Original PR Details:**
    - Title: Prepare release: 0.11.0
    - Files changed: CHANGELOG.md
examples/next/package.json
examples/node/package.json
examples/svelte/package.json
packages/connector/package.json
packages/controller/package.json
packages/eslint/package.json
packages/keychain/package.json
packages/tsconfig/package.json

    Please review the documentation changes to ensure they accurately reflect the controller updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `controller_redirect` config, updates starter pack docs to Layerswap deposit-based purchases, and bumps compatibility guidance to v0.11.0.
> 
> - **Controller Configuration**
>   - Add `ControllerOptions.controller_redirect` for standalone flow redirects with preset support.
> - **Starter Packs**
>   - Document v0.11.0 shift to Layerswap deposit-based purchases (replaces backend flow) with improved bridging and transparency.
>   - Update purchase flow confirmation to include transaction hash display.
> - **Getting Started / Compatibility**
>   - Update compatibility guide to v0.11.0 (date refreshed) and bump `@cartridge/connector` and `@cartridge/controller` versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c5d1f26855c4187580972e8c6ee8229db1cd626. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->