### PR TITLE
docs: Update documentation for controller PR #2205

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "validate-twoslash": "node scripts/validate-twoslash.js"
   },
   "dependencies": {
-    "@cartridge/connector": "^0.10.7",
-    "@cartridge/controller": "^0.10.7",
+    "@cartridge/connector": "^0.11.1",
+    "@cartridge/controller": "^0.11.1",
     "@starknet-io/get-starknet-core": "^4.0.8",
     "@starknet-io/types-js": "^0.9.2",
     "@starknet-react/chains": "^5.0.3",

--- a/src/pages/controller/getting-started.mdx
+++ b/src/pages/controller/getting-started.mdx
@@ -205,17 +205,17 @@ const sessionConnector = new SessionConnector({
 
 ## Compatibility Guide
 
-The following common dependencies are compatible with the latest version of Cartridge Controller (v0.10.3):
+The following common dependencies are compatible with the latest version of Cartridge Controller (v0.11.1):
 
 :::note
 This ecosystem is evolving rapidly.
-This information is accurate as of September 24, 2025.
+This information is accurate as of November 10, 2025.
 :::
 
 ```ts
   "@cartridge/arcade": "0.0.2"
-  "@cartridge/connector": "0.10.3"
-  "@cartridge/controller": "0.10.3"
+  "@cartridge/connector": "0.11.1"
+  "@cartridge/controller": "0.11.1"
   "@cartridge/presets": "0.5.4"
   "@dojoengine/core": "^1.7.0"
   "@dojoengine/predeployed-connector": "1.7.0-preview.3"


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2205

    **Original PR Details:**
    - Title: Prepare release: 0.11.1
    - Files changed: examples/next/package.json
examples/node/package.json
examples/svelte/package.json
packages/connector/package.json
packages/controller/package.json
packages/eslint/package.json
packages/keychain/package.json
packages/tsconfig/package.json

    Please review the documentation changes to ensure they accurately reflect the controller updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps @cartridge/connector and @cartridge/controller to 0.11.1 and updates the getting-started compatibility guide and date to match.
> 
> - **Dependencies**:
>   - Upgrade `@cartridge/connector` and `@cartridge/controller` in `package.json` to `^0.11.1`.
> - **Docs** (`src/pages/controller/getting-started.mdx`):
>   - Update Compatibility Guide to Controller `v0.11.1`.
>   - Adjust example dependency pins for `@cartridge/connector` and `@cartridge/controller` to `0.11.1`.
>   - Refresh accuracy date to `November 10, 2025`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c917fce5ec31e958a2a9e06e8528f704f27bf8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->