### PR TITLE
docs: Update documentation for controller PR #2213

### DIFF
--- a/src/pages/controller/starter-packs.md
+++ b/src/pages/controller/starter-packs.md
@@ -31,6 +31,11 @@ const controller = new Controller();
 // Open an existing starterpack by ID (works for both paid and free packs)
 controller.openStarterPack("starterpack-id-123");
 
+// Open a claimable starterpack with preimage for verification
+controller.openStarterPack("starterpack-id-123", {
+  preimage: "verification-hash-for-claim"
+});
+
 // Or create a custom starterpack with full configuration
 const customPack: StarterPack = {
   name: "Beginner Pack",
@@ -51,30 +56,55 @@ controller.openStarterPack(customPack);
 
 ## API Reference
 
-### openStarterPack(options: string | StarterPack)
+### openStarterPack(id: string | number | StarterPack, options?: StarterpackOptions)
 
 Opens the starterpack interface for a specific starterpack bundle or a custom starter pack configuration. This method works for both paid starterpacks (requiring purchase) and free starterpacks (that can be claimed based on eligibility).
 
 ```typescript
-controller.openStarterPack(options: string | StarterPack);
+controller.openStarterPack(id: string | number | StarterPack, options?: StarterpackOptions);
 ```
 
 **Parameters:**
-- `options` (string | StarterPack): Either a starterpack ID string for existing packs, or a complete StarterPack configuration object for custom packs
+- `id` (string | number | StarterPack): Either a starterpack ID (string or number) for existing packs, or a complete StarterPack configuration object for custom packs
+- `options` (StarterpackOptions, optional): Additional options for the starterpack, including preimage for claim verification
 
 **Returns:** `void`
+
+#### StarterpackOptions
+
+```typescript
+type StarterpackOptions = {
+  /** The preimage to use for claim verification */
+  preimage?: string;
+};
+```
+
+**Properties:**
+- `preimage` (string, optional): A verification hash used for claimable starterpacks to validate eligibility
 
 **Usage Examples:**
 
 ```typescript
-// Backward compatible - existing usage with string ID
+// Purchase starterpack with string ID
 const handleBuyStarterpack = () => {
   controller.openStarterPack("beginner-pack-2024");
 };
 
-// Offer free claimable starterpack
+// Purchase starterpack with numeric ID
+const handleBuyNumericStarterpack = () => {
+  controller.openStarterPack(123);
+};
+
+// Claim free starterpack without verification
 const handleClaimStarterpack = () => {
   controller.openStarterPack("free-welcome-pack-2024");
+};
+
+// Claim starterpack with preimage verification
+const handleClaimWithPreimage = () => {
+  controller.openStarterPack("claim-dopewars-mainnet", {
+    preimage: "verification-hash-for-eligibility"
+  });
 };
 
 // New - custom starter pack with outside execution


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2213

    **Original PR Details:**
    - Title: refactor: move preimage into options for future extensibility
    - Files changed: examples/next/src/components/Starterpack.tsx
packages/controller/src/controller.ts
packages/controller/src/types.ts
packages/keychain/src/utils/connection/index.ts

    Please review the documentation changes to ensure they accurately reflect the controller updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Revamps `starter-packs.md` to reflect `openStarterPack(id, options?)` API, adds `StarterpackOptions.preimage`, and updates examples (including numeric IDs and claim verification).
> 
> - **Docs Update (`src/pages/controller/starter-packs.md`)**:
>   - **API Change**: Replace `openStarterPack(options: string | StarterPack)` with `openStarterPack(id: string | number | StarterPack, options?: StarterpackOptions)`.
>     - Add numeric ID support for `id`.
>     - Introduce `StarterpackOptions` with optional `preimage` for claim verification.
>   - **Examples**:
>     - Add preimage-based claim example in Quick Start and Usage.
>     - Add purchase example using numeric ID.
>   - **Reference**:
>     - Document `StarterpackOptions` type and `preimage` property.
>     - Update parameter descriptions and signature snippets accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9892f221657e617e5cbe337d0ae143a766925279. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->