### PR TITLE
docs: Update documentation for controller PR #2219

### DIFF
--- a/src/pages/controller/configuration.md
+++ b/src/pages/controller/configuration.md
@@ -31,7 +31,7 @@ export type ControllerOptions = {
     origin?: string;  // The origin of keychain
     starterPackId?: string;  // The ID of the starter pack to use
     feeSource?: FeeSource;  // The fee source to use for execute from outside
-    signupOptions?: AuthOptions;  // Signup options (order reflects UI. Group socials and wallets together) - also available on SessionProvider
+    signupOptions?: AuthOptions;  // Signup options (order reflects UI. Group socials and wallets together)
     shouldOverridePresetPolicies?: boolean;  // When true, manually provided policies override preset policies. Default is false
     namespace?: string;  // The namespace to use to fetch trophies data from indexer
     tokens?: Tokens;  // The tokens to be listed on Inventory modal


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2219

    **Original PR Details:**
    - Title: feat: add signupOptions support to SessionProvider
    - Files changed: examples/next/src/components/providers/StarknetProvider.tsx
packages/controller/src/session/provider.ts

    Please review the documentation changes to ensure they accurately reflect the controller updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `signupOptions` to `SessionOptions` docs with supported auth methods and example usage across ControllerConnector/SessionConnector, and updates disconnect redirect example.
> 
> - **Sessions Documentation**:
>   - **Session Options**: Add `signupOptions?: AuthOptions` to `SessionOptions`.
>   - **Authentication Options**: Define `AuthOptions` and list supported methods (`google`, `webauthn`, `discord`, `walletconnect`, `metamask`, `password`, `rabby`).
>   - **Examples**:
>     - Shared `signupOptions` configuration used with `ControllerConnector` and `SessionConnector`.
>     - Update disconnect redirect example to include `signupOptions`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cfe905ad4ec2b47dfb8d17fe4581cd5be94e84b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->