### PR TITLE
docs: transfer service to another team

### DIFF
--- a/src/pages/slot/getting-started.md
+++ b/src/pages/slot/getting-started.md
@@ -57,6 +57,12 @@ slot deployments update <Project Name> torii --version v0.3.5
 slot deployments delete <Project Name> torii
 ```
 
+### Transfer a service to another team
+
+```sh
+slot d transfer <Project Name> <katana | torii> <To Team Name>
+```
+
 ### Read service logs
 
 ```sh


### PR DESCRIPTION
Add documentation for the 'slot d transfer' command that allows transferring a service from one team to another. Added in the deployment management section after delete operation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds docs for `slot d transfer` to move a service to another team in `src/pages/slot/getting-started.md`.
> 
> - **Documentation**:
>   - Update `src/pages/slot/getting-started.md` to include a new section: transferring a service to another team.
>     - Adds command usage: `slot d transfer <Project Name> <katana | torii> <To Team Name>`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a86a7de1d8bbd109f106201a35d6e4f057123a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->