### PR TITLE
docs: Add link to Capacitor project website

### DIFF
--- a/src/pages/controller/native/capacitor.md
+++ b/src/pages/controller/native/capacitor.md
@@ -5,7 +5,7 @@ description: Wrap your web app for native iOS and Android distribution using Cap
 
 # Capacitor
 
-Capacitor allows you to wrap an existing web application for native iOS and Android distribution.
+[Capacitor](https://capacitorjs.com/) allows you to wrap an existing web application for native iOS and Android distribution.
 This approach uses the same web-based Controller integration with session-based authentication via deep links.
 
 ## When to Use Capacitor


### PR DESCRIPTION
## Summary
- Adds a hyperlink to the official Capacitor website (https://capacitorjs.com/) in the opening paragraph of the Capacitor native integration page

## Test plan
- [ ] Verify the link renders correctly on the documentation site
- [ ] Confirm the link navigates to the correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)