### PR TITLE
docs: Fix StarknetChainId constant from SN_MAINNET to SN_MAIN

### DIFF
--- a/src/pages/controller/examples/telegram.md
+++ b/src/pages/controller/examples/telegram.md
@@ -61,7 +61,7 @@ import { RPC_URL, SESSION_POLICIES, REDIRECT_URI } from "./config";
 const connector = new SessionConnector({
   policies: SESSION_POLICIES,
   rpc: RPC_URL,
-  chainId: constants.StarknetChainId.SN_MAINNET,
+  chainId: constants.StarknetChainId.SN_MAIN,
   redirectUrl: REDIRECT_URI,
 });
 

--- a/src/pages/controller/native/capacitor.md
+++ b/src/pages/controller/native/capacitor.md
@@ -56,12 +56,13 @@ Use `SessionConnector` instead of `ControllerConnector` for native apps.
 The key difference is the `redirectUrl` parameter, which uses a custom URL scheme.
 
 ```typescript
+import { constants } from "starknet";
 import { SessionConnector } from "@cartridge/connector";
 
 const controller = new SessionConnector({
   policies,
   rpc: "https://api.cartridge.gg/x/starknet/mainnet",
-  chainId: "SN_MAINNET",
+  chainId: constants.StarknetChainId.SN_MAIN,
   redirectUrl: "myapp://open",           // Custom URL scheme
   disconnectRedirectUrl: "myapp://open",
   signupOptions: ["google", "discord", "webauthn", "password"],


### PR DESCRIPTION
## Summary
- Updates `constants.StarknetChainId.SN_MAINNET` to `constants.StarknetChainId.SN_MAIN` in telegram.md
- Updates hardcoded `"SN_MAINNET"` string to `constants.StarknetChainId.SN_MAIN` in capacitor.md (also adds the required import)

## Test plan
- [ ] Verify code examples compile correctly with starknet.js

🤖 Generated with [Claude Code](https://claude.ai/claude-code)