### PR TITLE
docs: Limit outline sidebar depth to h2 headings

### DIFF
--- a/src/pages/arcade/marketplace.md
+++ b/src/pages/arcade/marketplace.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: Marketplace Setup
 description: Learn how to set up your game's Marketplace
 ---

--- a/src/pages/arcade/overview.md
+++ b/src/pages/arcade/overview.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: Arcade Overview
 description: Discover Arcade, the ultimate hub for onchain games. Register, manage, and publish your games with ease — no permission required.
 ---

--- a/src/pages/arcade/setup.md
+++ b/src/pages/arcade/setup.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: Arcade Setup
 description: Learn how to register, configure, and index your game with Arcade, including metadata management, edition publishing, and Torii integration.
 ---

--- a/src/pages/controller/achievements.md
+++ b/src/pages/controller/achievements.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: Achievements
 description: Learn how to implement Cartridge's Achievement system that allows games to reward players for completing in-game objectives and track their progress.
 ---

--- a/src/pages/controller/architecture.md
+++ b/src/pages/controller/architecture.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: Architecture
 description: Technical overview of the Controller smart contract architecture, security model, and on-chain mechanisms.
 ---

--- a/src/pages/controller/booster-packs.md
+++ b/src/pages/controller/booster-packs.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 description: Learn about booster pack claims - a reward system that allows eligible users to claim game credits, tokens, and special game passes through Merkle Drop technology.
 title: Booster Packs
 ---

--- a/src/pages/controller/coinbase-onramp.md
+++ b/src/pages/controller/coinbase-onramp.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 description: Learn how to integrate Coinbase onramp functionality for fiat-to-crypto purchases within your gaming application.
 title: Coinbase Onramp Integration
 ---

--- a/src/pages/controller/configuration.md
+++ b/src/pages/controller/configuration.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 description: Explore the configuration options available for Cartridge Controller, including chain settings, session management, and theme customization.
 title: Controller Configuration
 ---

--- a/src/pages/controller/examples/node.md
+++ b/src/pages/controller/examples/node.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: Controller Node.js Integration
 description: Learn how to integrate the Cartridge Controller into your Node.js application, including setup, configuration, and usage examples.
 ---

--- a/src/pages/controller/examples/react.md
+++ b/src/pages/controller/examples/react.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: Controller React Integration
 description: Learn how to integrate the Cartridge Controller into your React application, including setup, configuration, and usage examples.
 ---

--- a/src/pages/controller/examples/rust.md
+++ b/src/pages/controller/examples/rust.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: Controller Rust Integration
 description: Learn how to integrate the Cartridge Controller into your Rust application, including setup, configuration, and usage examples.
 ---

--- a/src/pages/controller/examples/svelte.md
+++ b/src/pages/controller/examples/svelte.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: Controller Svelte Integration
 description: Learn how to integrate the Cartridge Controller into your Svelte application, including setup, configuration, and usage examples.
 ---

--- a/src/pages/controller/examples/telegram.md
+++ b/src/pages/controller/examples/telegram.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: Controller Telegram Integration
 description: Learn how to integrate the Cartridge Controller into your Telegram Mini App, including setup, configuration, and usage examples.
 ---

--- a/src/pages/controller/getting-started.mdx
+++ b/src/pages/controller/getting-started.mdx
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 description: Get started with Cartridge Controller by learning how to install, initialize, and integrate it into your application with various frameworks.
 title: Controller Getting Started
 ---

--- a/src/pages/controller/inventory.md
+++ b/src/pages/controller/inventory.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 description: Learn how to use and configure the Cartridge Controller's Inventory modal for managing ERC-20 and ERC-721 assets.
 title: Controller Inventory Management
 ---

--- a/src/pages/controller/native/android.md
+++ b/src/pages/controller/native/android.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: Android
 description: Integrate Cartridge Controller into Android applications using Kotlin and UniFFI bindings.
 ---

--- a/src/pages/controller/native/capacitor.md
+++ b/src/pages/controller/native/capacitor.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: Capacitor
 description: Wrap your web app for native iOS and Android distribution using Capacitor and Controller's SessionConnector.
 ---

--- a/src/pages/controller/native/headless.md
+++ b/src/pages/controller/native/headless.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: Headless Controller
 description: Using user-supplied signing keys with Controller for server-side and automated applications.
 ---

--- a/src/pages/controller/native/ios.md
+++ b/src/pages/controller/native/ios.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: iOS
 description: Integrate Cartridge Controller into iOS applications using Swift and UniFFI bindings.
 ---

--- a/src/pages/controller/native/overview.md
+++ b/src/pages/controller/native/overview.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: Native Integration
 description: Integrate Cartridge Controller into native and mobile applications.
 ---

--- a/src/pages/controller/native/react-native.md
+++ b/src/pages/controller/native/react-native.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: React Native
 description: Integrate Cartridge Controller into React Native applications using Controller.c and TurboModules.
 ---

--- a/src/pages/controller/native/session-flow.md
+++ b/src/pages/controller/native/session-flow.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: Session Flow
 description: Understanding the browser-based session linking flow for native Controller integration.
 ---

--- a/src/pages/controller/overview.md
+++ b/src/pages/controller/overview.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 description: Explore Cartridge Controller, a gaming-focused smart contract wallet that makes Web3 gaming accessible and fun with features like session keys, identity management, and customization options.
 title: Controller Overview
 ---

--- a/src/pages/controller/presets.md
+++ b/src/pages/controller/presets.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: Controller Presets
 description: Learn how to customize your Cartridge Controller.
 ---

--- a/src/pages/controller/quests.md
+++ b/src/pages/controller/quests.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: Quests
 description: Learn how to implement Cartridge's Quest system that allows games to create time-based challenges with rewards and progress tracking for players.
 ---

--- a/src/pages/controller/sessions.md
+++ b/src/pages/controller/sessions.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 title: Sessions and Policies
 description: Learn about Cartridge Controller's session-based authentication and policy-based transaction approvals system.
 ---

--- a/src/pages/controller/signer-management.md
+++ b/src/pages/controller/signer-management.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 description: Learn how to add and manage multiple authentication methods (signers) for your Cartridge Controller account, including Passkeys, social login (Google, Discord), and external wallets.
 title: Signer Management
 ---

--- a/src/pages/controller/starter-packs.md
+++ b/src/pages/controller/starter-packs.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 description: Learn how to integrate starter packs in your game - pre-configured bundles of game assets and credits that players can purchase or claim with streamlined payment flows across multiple blockchains.
 title: Starter Packs
 ---

--- a/src/pages/controller/toast-notifications.md
+++ b/src/pages/controller/toast-notifications.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 description: Learn how to use the Controller Toast API to display contextual notifications including transactions, achievements, network switches, and marketplace activities.
 title: Toast Notifications
 ---

--- a/src/pages/controller/usernames.md
+++ b/src/pages/controller/usernames.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 description: Discover how to use Cartridge Controller's username and address lookup service, including API access, helper methods, and the new autocomplete features.
 title: Username Lookup
 ---

--- a/src/pages/slot/billing.md
+++ b/src/pages/slot/billing.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 description: Learn how to manage billing for Slot services through team-based credit management.
 title: Billing
 ---

--- a/src/pages/slot/getting-started.md
+++ b/src/pages/slot/getting-started.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 description: Get started with Slot, the execution layer of Dojo that provides low latency, dedicated, provable execution contexts for blockchain applications.
 title: Slot Getting Started
 ---

--- a/src/pages/slot/observability.md
+++ b/src/pages/slot/observability.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 description: Monitor your Slot deployments with integrated Prometheus metrics and Grafana dashboards.
 title: Slot Observability
 ---

--- a/src/pages/slot/paymaster.md
+++ b/src/pages/slot/paymaster.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 description: Manage Slot paymasters to sponsor transaction fees for your applications.
 title: Paymaster Management
 ---

--- a/src/pages/slot/rpc.md
+++ b/src/pages/slot/rpc.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 description: Cartridge RPC endpoints for Starknet mainnet and Sepolia testnet with authentication and CORS configuration.
 title: Cartridge RPC
 ---

--- a/src/pages/slot/scale.md
+++ b/src/pages/slot/scale.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 description: Scale your slot deployments by upgrading to paid instances.
 title: Scale your deployments
 ---

--- a/src/pages/slot/vrng.md
+++ b/src/pages/slot/vrng.md
@@ -1,4 +1,5 @@
 ---
+showOutline: 2
 description: Explore Cartridge's Verifiable Random Number Generator (vRNG), a system designed to provide cheap, atomic, and verifiable randomness for fully onchain games.
 title: vRNG Overview
 ---


### PR DESCRIPTION
## Summary
- Add `showOutline: 2` frontmatter to all documentation pages
- Reduces clutter in the "On this page" sidebar by only showing h2 headings
- Improves navigation for long pages with deeply nested content (e.g., Configuration)

## Test plan
- [ ] Run `pnpm dev` and verify the outline sidebar shows only top-level sections
- [ ] Check the Configuration page specifically, which had the most nested headings

🤖 Generated with [Claude Code](https://claude.com/claude-code)