### PR TITLE
docs: Update documentation for controller PR #2362

### DIFF
--- a/src/pages/controller/starter-packs.md
+++ b/src/pages/controller/starter-packs.md
@@ -38,16 +38,21 @@ controller.openStarterPack(42);
 
 ## API Reference
 
-### openStarterPack(starterpackId: string | number)
+### openStarterPack(starterpackId: string | number, options?: StarterpackOptions)
 
 Opens the starterpack interface for a specific starterpack bundle. This method works for both paid starterpacks (requiring purchase) and claimed starterpacks (that can be claimed based on eligibility).
 
 ```typescript
-controller.openStarterPack(starterpackId: string | number);
+controller.openStarterPack(starterpackId: string | number, options?: StarterpackOptions);
 ```
 
 **Parameters:**
 - `starterpackId` (string | number): The starterpack ID. String IDs are used for claimed packs, numeric IDs for onchain packs
+- `options` (StarterpackOptions, optional): Configuration options for the starterpack
+
+**StarterpackOptions:**
+- `preimage` (string, optional): The preimage to use for claimed starterpacks
+- `onPurchaseComplete` (function, optional): Callback fired after the Play button closes the starterpack modal
 
 **Returns:** `void`
 
@@ -59,9 +64,21 @@ const handleBuyStarterpack = () => {
   controller.openStarterPack("beginner-pack-2024");
 };
 
-// Open a free claimable starterpack
+// Open a starterpack with play callback
+const handleBuyWithCallback = () => {
+  controller.openStarterPack("beginner-pack-2024", {
+    onPurchaseComplete: () => {
+      console.log("Starterpack purchase completed!");
+      // Redirect to game or refresh inventory
+    }
+  });
+};
+
+// Open a free claimable starterpack with preimage
 const handleClaimStarterpack = () => {
-  controller.openStarterPack("free-welcome-pack-2024");
+  controller.openStarterPack("free-welcome-pack-2024", {
+    preimage: "claim-preimage-data"
+  });
 };
 
 // Open an onchain starterpack using numeric ID


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2362

    **Original PR Details:**
    - Title: Add starterpack play callback
    - Files changed: examples/next/src/components/Profile.tsx
examples/next/src/components/Starterpack.tsx
packages/controller/src/controller.ts
packages/controller/src/iframe/keychain.ts
packages/controller/src/types.ts
packages/keychain/src/components/purchasenew/pending/base.tsx
packages/keychain/src/components/purchasenew/pending/bridge.tsx
packages/keychain/src/components/purchasenew/success.tsx
packages/keychain/src/hooks/connection.ts
packages/keychain/src/hooks/starterpack/index.ts
packages/keychain/src/hooks/starterpack/play.test.tsx
packages/keychain/src/hooks/starterpack/play.ts

    Please review the documentation changes to ensure they accurately reflect the controller updates.