### PR TITLE
docs: Update documentation for controller PR #2378

### DIFF
--- a/src/pages/controller/coinbase-onramp.md
+++ b/src/pages/controller/coinbase-onramp.md
@@ -131,7 +131,7 @@ When testing Coinbase onramp integration:
 - **Cost Breakdown UI**: Test fee transparency components with various purchase amounts
 
 :::note
-Coinbase onramp integration is automatically included in Cartridge Controller v0.12.0+ and does not require additional configuration for basic usage. Enhanced features including Apple Pay checkout, comprehensive cost breakdown, and improved order management are available in v0.12.2+.
+Coinbase onramp integration is automatically included in Cartridge Controller v0.12.0+ and does not require additional configuration for basic usage. Enhanced features including Apple Pay checkout, comprehensive cost breakdown, and improved order management are available in v0.12.2+. The latest version v0.12.3 includes additional sandbox configuration improvements and bug fixes for enhanced reliability.
 :::
 
 ## Next Steps

--- a/src/pages/controller/getting-started.mdx
+++ b/src/pages/controller/getting-started.mdx
@@ -327,7 +327,7 @@ const sessionConnector = new SessionConnector({
 
 ## Compatibility Guide
 
-The following common dependencies are compatible with the latest version of Cartridge Controller (v0.11.3-alpha.1):
+The following common dependencies are compatible with the latest version of Cartridge Controller (v0.12.3):
 
 :::note
 This ecosystem is evolving rapidly.
@@ -336,8 +336,8 @@ This information is accurate as of December 1, 2025.
 
 ```ts
   "@cartridge/arcade": "0.0.2"
-  "@cartridge/connector": "0.11.3-alpha.1"
-  "@cartridge/controller": "0.11.3-alpha.1"
+  "@cartridge/connector": "0.12.3"
+  "@cartridge/controller": "0.12.3"
   "@cartridge/presets": "0.5.4"
   "@dojoengine/core": "^1.7.0"
   "@dojoengine/predeployed-connector": "1.7.0-preview.3"


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2378

    **Original PR Details:**
    - Title: Prepare release: 0.12.3
    - Files changed: CHANGELOG.md
examples/capacitor/package.json
examples/next/package.json
examples/node/package.json
examples/svelte/package.json
packages/connector/package.json
packages/controller/package.json
packages/eslint/package.json
packages/keychain/package.json
packages/tsconfig/package.json

    Please review the documentation changes to ensure they accurately reflect the controller updates.