### PR TITLE
docs: Rewrite connector section as ControllerProvider vs SessionProvider

### DIFF
--- a/src/pages/controller/getting-started.mdx
+++ b/src/pages/controller/getting-started.mdx
@@ -185,6 +185,10 @@ Because the session key is not the owner key, on-chain registration is required 
 | **Auth UX** | Embedded keychain modal | Browser redirect + deep link back |
 | **After auth** | Iframe signs each transaction | Transactions execute without UI |
 
+Both providers support [session policies](/controller/sessions.md) to control which transactions can be signed automatically.
+With `ControllerProvider`, policies let the iframe approve matching transactions without prompting the user.
+With `SessionProvider`, the session key is registered with the approved policies on-chain, so all matching transactions execute without further interaction.
+
 ### ControllerConnector (Web)
 
 `ControllerConnector` wraps `ControllerProvider` for use with frontend frameworks like `starknet-react`.


### PR DESCRIPTION
## Summary

- Reframes the getting-started connector section around **providers** (`ControllerProvider` vs `SessionProvider`) instead of connectors, since providers do the real work
- Explains the iframe-based (owner key) vs redirect-based (ephemeral session key) signing models
- Adds a comparison table covering environment, signing, on-chain registration, auth UX, and post-auth behavior
- Positions `ControllerConnector` and `SessionConnector` as thin framework wrappers

## Test plan

- [ ] Verify the docs site builds cleanly (`pnpm build`)
- [ ] Review the rendered "ControllerProvider vs SessionProvider" section for clarity
- [ ] Check that existing code examples for both connectors are intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)