### PR TITLE
docs: Update documentation for controller PR #2389

### DIFF
--- a/src/pages/controller/getting-started.mdx
+++ b/src/pages/controller/getting-started.mdx
@@ -332,50 +332,6 @@ const sessionConnector = new SessionConnector({
 });
 ```
 
-## Compatibility Guide
-
-The following common dependencies are compatible with the latest version of Cartridge Controller (v0.13.4):
-
-:::note
-This ecosystem is evolving rapidly.
-This information is accurate as of February 6, 2026.
-:::
-
-```ts
-  "@cartridge/arcade": "0.0.2"
-  "@cartridge/connector": "0.13.4"
-  "@cartridge/controller": "0.13.4"
-  "@cartridge/presets": "0.5.4"
-  "@dojoengine/core": "^1.7.0"
-  "@dojoengine/predeployed-connector": "1.7.0-preview.3"
-  "@dojoengine/sdk": "^1.7.2"
-  "@dojoengine/torii-client": "1.7.0-preview.3"
-  "@dojoengine/torii-wasm": "^1.7.2"
-  "@dojoengine/utils": "1.7.0-preview.3"
-  "@starknet-io/types-js": "^0.8.4"
-  "@starknet-react/chains": "^5.0.1"
-  "@starknet-react/core": "^5.0.1"
-  "@tailwindcss/vite": "^4.1.4"
-  "@types/node": "^22.13.1"
-  "@types/react": "^19.1.0"
-  "@types/react-dom": "^19.1.0"
-  "bignumber.js": "^9.3.0"
-  "lucide-react": "^0.523.0"
-  "prettier": "^3.6.1"
-  "prettier-plugin-tailwindcss": "^0.6.13"
-  "react": "^19.1.0"
-  "react-dom": "^19.1.0"
-  "recharts": "^3.1.0"
-  "sonner": "^2.0.5"
-  "starknet": "^8.1.2"
-  "starknetkit": "^v2.12.1"
-  "tailwindcss": "^4.1.4"
-  "typescript": "^5.8.3"
-  "vite": "^6.3.3"
-  "vite-plugin-wasm": "^3.4.1"
-  "zustand": "^5.0.3"
-```
-
 ### Migration Notes for v0.10.0
 
 #### StarkNet v8 Breaking Changes


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2389

    **Original PR Details:**
    - Title: Prepare release: 0.13.4
    - Files changed: CHANGELOG.md
examples/capacitor/package.json
examples/next/package.json
examples/node/package.json
examples/svelte/package.json
output.txt
packages/connector/package.json
packages/controller/package.json
packages/eslint/package.json
packages/keychain/package.json
packages/tsconfig/package.json

    Please review the documentation changes to ensure they accurately reflect the controller updates.