### PR TITLE
feat: Add Slot deployment skills

### DIFF
--- a/.agents/skills/slot-deploy/SKILL.md
+++ b/.agents/skills/slot-deploy/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: slot-deploy
+description: Create, update, and manage Slot deployments for Katana and Torii services.
+---
+
+# Slot Deploy
+
+Manage the lifecycle of Slot deployments — Katana (execution layer) and Torii (indexer).
+
+## Prerequisites
+
+Install the Slot CLI:
+
+```sh
+curl -L https://slot.cartridge.sh | bash
+```
+
+Authenticate:
+
+```sh
+slot auth login
+```
+
+For CI/scripts, generate a token and set the `SLOT_AUTH` env var:
+
+```sh
+slot auth token
+```
+
+## Creating Deployments
+
+### Katana
+
+```sh
+slot deployments create <Project Name> katana
+```
+
+### Torii
+
+Torii requires a TOML configuration file:
+
+```sh
+slot deployments create <Project Name> torii --config <path/to/torii.toml>
+```
+
+Minimal `torii.toml`:
+
+```toml
+rpc = "https://api.cartridge.gg/x/starknet/mainnet"
+world_address = "0x3fa481f41522b90b3684ecfab7650c259a76387fab9c380b7a959e3d4ac69f"
+```
+
+Extended config options:
+
+```toml
+[indexing]
+allowed_origins = ["*"]
+index_pending = true
+index_transactions = false
+polling_interval = 1000
+contracts = [
+  "erc20:<contract-address>",
+  "erc721:<contract-address>"
+]
+
+[events]
+raw = true
+historical = ["namespace-EventName"]
+```
+
+When you create a service with a new project name, a team is automatically created.
+
+## Updating Deployments
+
+```sh
+slot deployments update <Project Name> torii --version v1.0.0
+slot deployments update <Project Name> torii --config <path/to/torii.toml>
+slot deployments update <Project Name> torii --replicas 3
+```
+
+## Deleting Deployments
+
+```sh
+slot deployments delete <Project Name> <katana | torii>
+```
+
+## Inspecting Deployments
+
+```sh
+# List all deployments
+slot deployments list
+
+# View configuration
+slot deployments describe <Project Name> <katana | torii>
+
+# Read logs
+slot deployments logs <Project Name> <katana | torii>
+
+# View predeployed Katana accounts
+slot deployments accounts <Project Name> katana
+```
+
+## Transferring Services
+
+Transfer a service to another team:
+
+```sh
+slot d transfer <Project Name> <katana | torii> <To Team Name>
+```
+
+## Observability
+
+Enable Prometheus and Grafana monitoring ($10/month per deployment).
+
+### On creation
+
+```sh
+slot deployments create <Project Name> --observability katana
+slot deployments create <Project Name> --observability torii --config <path/to/torii.toml>
+```
+
+### On existing deployment
+
+```sh
+slot deployments update <Project Name> --observability katana
+slot deployments update <Project Name> --observability torii
+```
+
+### Accessing dashboards
+
+- Prometheus: `https://<deployment-url>/prometheus`
+- Grafana: `https://<deployment-url>/grafana`
+
+Both are protected by username/password credentials provided when observability is enabled.

--- a/.agents/skills/slot-paymaster/SKILL.md
+++ b/.agents/skills/slot-paymaster/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: slot-paymaster
+description: Set up and manage Slot paymasters to sponsor transaction fees for gasless user experiences.
+---
+
+# Slot Paymaster
+
+Manage paymasters that sponsor transaction fees, enabling gasless experiences for users.
+Zero integration required — when enabled, eligible transactions are automatically sponsored.
+
+## Availability
+
+- **Testnet**: Automatically enabled, no setup required
+- **Mainnet**: Self-served via Slot CLI
+
+## Creating a Paymaster
+
+Requires an authenticated session (`slot auth login`) and a team with credits.
+
+```sh
+slot paymaster <name> create --team <team> --budget <amount> --unit CREDIT
+```
+
+The budget is deducted from the team's credit balance.
+1 CREDIT = $0.01 USD.
+
+## Budget Management
+
+```sh
+# Increase budget
+slot paymaster <name> budget increase --amount <amount> --unit CREDIT
+
+# Decrease budget
+slot paymaster <name> budget decrease --amount <amount> --unit CREDIT
+```
+
+## Policy Management
+
+Policies define which contracts and entrypoints the paymaster will sponsor.
+
+### Add from preset (recommended)
+
+Use verified contract presets from the Dojo ecosystem:
+
+```sh
+slot paymaster <name> policy add-from-preset --name <preset-name>
+```
+
+Presets are maintained at https://github.com/cartridge-gg/presets/tree/main/configs
+
+### Add a single policy
+
+```sh
+slot paymaster <name> policy add --contract <address> --entrypoint <entry-point>
+```
+
+### Add from JSON
+
+```sh
+slot paymaster <name> policy add-from-json --file <path>
+```
+
+JSON format:
+
+```json
+[
+  {
+    "contractAddress": "0x1234...abcd",
+    "entrypoint": "move_player"
+  },
+  {
+    "contractAddress": "0x5678...efgh",
+    "entrypoint": "attack",
+    "predicate": {
+      "address": "0x9abc...1234",
+      "entrypoint": "check_attack_eligibility"
+    }
+  }
+]
+```
+
+Predicates are optional.
+When present, the predicate contract is called first — the transaction is only sponsored if it returns `true`.
+
+### Remove policies
+
+```sh
+# Remove one
+slot paymaster <name> policy remove --contract <address> --entrypoint <entry-point>
+
+# Remove all (requires confirmation)
+slot paymaster <name> policy remove-all
+
+# List current policies
+slot paymaster <name> policy list
+```
+
+## Info and Configuration
+
+```sh
+# View paymaster details, budget, and policy count
+slot paymaster <name> info
+
+# Rename
+slot paymaster <name> update --name <new-name>
+
+# Transfer to different team
+slot paymaster <name> update --team <new-team>
+
+# Enable/disable
+slot paymaster <name> update --active false
+slot paymaster <name> update --active true
+```
+
+## Monitoring
+
+### Stats
+
+```sh
+slot paymaster <name> stats --last <period>
+```
+
+Period options: `1hr`, `2hr`, `24hr`, `1day`, `2day`, `7day`, `1week`.
+
+### Transaction history
+
+```sh
+slot paymaster <name> transactions [OPTIONS]
+```
+
+Options:
+- `--filter SUCCESS|REVERTED|ALL`
+- `--last <period>`
+- `--order-by FEES_ASC|FEES_DESC|EXECUTED_AT_DESC|EXECUTED_AT_ASC`
+- `--limit <n>` (max 1000)
+
+### Dune Analytics
+
+Generate SQL queries for Dune dashboards:
+
+```sh
+# With actual timestamps
+slot paymaster <name> dune --last 24hr
+
+# With template parameters for Dune dashboards
+slot paymaster <name> dune --dune-params
+```
+
+## Common Workflow: New Game Setup
+
+```sh
+# Create paymaster
+slot paymaster my-game-pm create --team my-team --budget 1000 --unit CREDIT
+
+# Add game contract policies
+slot paymaster my-game-pm policy add --contract 0x123...abc --entrypoint move_player
+slot paymaster my-game-pm policy add --contract 0x123...abc --entrypoint attack_enemy
+
+# Verify setup
+slot paymaster my-game-pm info
+```

--- a/.agents/skills/slot-rpc/SKILL.md
+++ b/.agents/skills/slot-rpc/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: slot-rpc
+description: Configure Cartridge RPC endpoints with API token authentication and CORS whitelisting.
+---
+
+# Slot RPC
+
+Cartridge provides dedicated RPC endpoints for Starknet with authentication and CORS support.
+
+## Endpoints
+
+- **Mainnet**: `https://api.cartridge.gg/x/starknet/mainnet`
+- **Sepolia**: `https://api.cartridge.gg/x/starknet/sepolia`
+
+## Pricing
+
+Free for up to 1M requests/month.
+Additional requests: $5/1M, charged to the team.
+
+## Authentication Methods
+
+### API Token
+
+```bash
+curl https://api.cartridge.gg/x/starknet/mainnet \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "starknet_chainId",
+    "params": [],
+    "id": 1
+  }'
+```
+
+### Domain Whitelisting
+
+For browser apps, whitelist domains to make direct RPC calls without exposing tokens.
+Whitelisted domains are rate-limited per IP.
+
+```javascript
+const response = await fetch('https://api.cartridge.gg/x/starknet/mainnet', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    jsonrpc: '2.0',
+    method: 'starknet_chainId',
+    params: [],
+    id: 1,
+  }),
+});
+```
+
+## Managing API Tokens
+
+```bash
+# Create a token
+slot rpc tokens create <KEY_NAME> --team <TEAM_NAME>
+
+# List tokens
+slot rpc tokens list --team <TEAM_NAME>
+
+# Delete a token
+slot rpc tokens delete <KEY_ID> --team <TEAM_NAME>
+```
+
+## Managing CORS Whitelist
+
+Whitelists are specified as root domains; all subdomains are automatically included.
+
+```bash
+# Add a domain
+slot rpc whitelist add <DOMAIN> --team <TEAM_NAME>
+
+# List whitelisted domains
+slot rpc whitelist list --team <TEAM_NAME>
+
+# Remove a domain
+slot rpc whitelist remove <ENTRY_ID> --team <TEAM_NAME>
+```
+
+## Viewing Logs
+
+```bash
+slot rpc logs --team <TEAM_NAME>
+```
+
+Options:
+- `--after <CURSOR>`: Pagination cursor
+- `--limit <NUMBER>`: Entries to return (default: 100)
+- `--since <DURATION>`: Time period (`30m`, `1h`, `24h`)
+
+Examples:
+
+```bash
+# Last 5 entries from past 30 minutes
+slot rpc logs --team my-team --limit 5 --since 30m
+
+# Paginate with cursor
+slot rpc logs --team my-team --after <cursor> --limit 5
+```

--- a/.agents/skills/slot-scale/SKILL.md
+++ b/.agents/skills/slot-scale/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: slot-scale
+description: Scale Slot deployments with paid tiers, replicas, and multi-region support.
+---
+
+# Slot Scale
+
+Scale deployments from development to production with paid tiers, replicas, and multi-region.
+
+## Instance Tiers
+
+| Tier      | Specs                | Storage | Cost       |
+|-----------|----------------------|---------|------------|
+| Basic     | Limited CPU & memory | 1GB     | $10/month  |
+| Pro       | 2 vCPU, 4GB RAM      | auto    | $50/month  |
+| Epic      | 4 vCPU, 8GB RAM      | auto    | $100/month |
+| Legendary | 8 vCPU, 16GB RAM     | auto    | $200/month |
+
+First 3 Basic tier deployments are free.
+Storage on premium tiers: $0.20/GB/month (auto-scaling).
+
+### Basic tier behavior
+
+- Scaled down automatically after a few hours of inactivity
+- Revived on first request
+- Deleted if unused for 30+ days
+
+### Premium tiers (Pro+)
+
+- Never scaled down or deleted while the team has credits
+- Auto storage scaling (never runs out of disk space)
+
+## Replicas
+
+Torii supports multiple replicas on premium tiers:
+
+```sh
+slot d create --tier epic my-project torii --replicas 3
+```
+
+Billed per replica (3 replicas = 3× tier cost).
+Katana does not support replicas.
+
+## Regions
+
+| Region        |
+|---------------|
+| `us-east`     |
+| `europe-west` |
+
+Deploy in multiple regions with `--regions`:
+
+```sh
+# Torii: multi-region with replicas
+slot d create --tier pro my-project torii --regions us-east,europe-west
+
+# Katana: single region only
+slot d create --tier pro my-project katana --regions europe-west
+```
+
+Billing: tier cost × regions × replicas.
+
+## Creating Paid Tier Deployments
+
+Ensure the team has credits (see `slot-teams` skill), then:
+
+```sh
+slot d create --tier epic --team my-team my-instance torii
+```
+
+## Upgrading an Existing Deployment
+
+Tiers can only be upgraded, not downgraded:
+
+```sh
+slot d update --tier epic my-instance torii
+```
+
+The team that owns the deployment must have sufficient credits.

--- a/.agents/skills/slot-teams/SKILL.md
+++ b/.agents/skills/slot-teams/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: slot-teams
+description: Manage Slot teams, billing, credits, and collaborators.
+---
+
+# Slot Teams
+
+Teams are the billing entity in Slot.
+They own credits used to pay for deployments, paymasters, RPC requests, and other services.
+
+## Credit System
+
+- Prepaid credits, deducted automatically
+- 1 CREDIT = $0.01 USD
+- Daily billing cycle (minimum 1-day charge)
+- Fund via credit card or cryptocurrency
+
+## Creating a Team
+
+```sh
+slot teams <team-name> create --email <email> [--address "address"] [--tax-id "id"]
+```
+
+A team is also auto-created when you create a deployment with a new project name.
+
+## Funding
+
+```sh
+slot auth fund
+```
+
+Opens a browser interface to select a team and add credits.
+Direct URL: `https://x.cartridge.gg/slot/fund`
+
+## Team Info
+
+```sh
+# View balance and details
+slot teams <team-name> info
+
+# View billing history
+slot teams <team-name> invoices
+
+# Update billing info
+slot teams <team-name> update [--email <email>] [--address "address"] [--tax-id "id"]
+```
+
+## Collaborators
+
+```sh
+# List members
+slot teams <team-name> list
+
+# Add a member (by controller username)
+slot teams <team-name> add <username>
+
+# Remove a member
+slot teams <team-name> remove <username>
+```
+
+## What Uses Credits
+
+| Service              | Cost                                          |
+|----------------------|-----------------------------------------------|
+| Basic deployment     | $10/month (first 3 free)                      |
+| Pro deployment       | $50/month                                     |
+| Epic deployment      | $100/month                                    |
+| Legendary deployment | $200/month                                    |
+| Storage (premium)    | $0.20/GB/month                                |
+| Paymaster budget     | Funded from team credits                      |
+| RPC requests         | Free 1M/month, then $5/1M                    |
+| Multi-region         | Tier cost × regions × replicas                |
+| Observability        | $10/month per deployment                      |
+
+## Troubleshooting
+
+### Insufficient credits
+
+```sh
+# Check balance
+slot teams <team-name> info
+
+# Fund the team
+slot auth fund
+
+# Retry your operation
+```
+
+### Service not starting
+
+- Verify team has credits: `slot teams <team-name> info`
+- Ensure service was created with `--team <team-name>`
+- Check that you're a member of the team

--- a/.agents/skills/slot-vrng/SKILL.md
+++ b/.agents/skills/slot-vrng/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: slot-vrng
+description: Integrate Cartridge's verifiable random number generator (vRNG) into onchain games.
+---
+
+# Slot vRNG
+
+Cartridge's Verifiable Random Number Generator provides cheap, atomic, verifiable randomness for onchain games.
+Randomness is generated and verified within a single transaction.
+
+## Contract Addresses
+
+| Network | Address |
+|---------|---------|
+| Mainnet | `0x051fea4450da9d6aee758bdeba88b2f665bcbf549d2c61421aa724e9ac0ced8f` |
+| Sepolia | `0x051fea4450da9d6aee758bdeba88b2f665bcbf549d2c61421aa724e9ac0ced8f` |
+
+## Cairo Interface
+
+```rust
+#[starknet::interface]
+trait IVrfProvider<TContractState> {
+    fn request_random(self: @TContractState, caller: ContractAddress, source: Source);
+    fn consume_random(ref self: TContractState, source: Source) -> felt252;
+}
+
+#[derive(Drop, Copy, Clone, Serde)]
+pub enum Source {
+    Nonce: ContractAddress,
+    Salt: felt252,
+}
+```
+
+### Source Types
+
+- `Source::Nonce(ContractAddress)`: Uses the address's internal nonce.
+Each request generates a different seed.
+- `Source::Salt(felt252)`: Uses a provided salt.
+Same salt = same random value.
+
+## Usage in Contracts
+
+```rust
+const VRF_PROVIDER_ADDRESS: starknet::ContractAddress =
+    starknet::contract_address_const::<0x051fea4450da9d6aee758bdeba88b2f665bcbf549d2c61421aa724e9ac0ced8f>();
+
+fn roll_dice(ref self: ContractState) {
+    let vrf_provider = IVrfProviderDispatcher { contract_address: VRF_PROVIDER_ADDRESS };
+    let player_id = get_caller_address();
+    let random_value = vrf_provider.consume_random(Source::Nonce(player_id));
+    // Use random_value in game logic
+}
+```
+
+## Executing vRNG Transactions
+
+`request_random` must be the first call in the multicall.
+The Cartridge Paymaster wraps the multicall with `submit_random` and `assert_consumed`.
+
+```js
+const call = await account.execute([
+  // First: request_random
+  {
+    contractAddress: VRF_PROVIDER_ADDRESS,
+    entrypoint: 'request_random',
+    calldata: CallData.compile({
+      caller: GAME_CONTRACT,
+      // Source::Nonce(address)
+      source: { type: 0, address: account.address },
+      // Or Source::Salt(felt252)
+      // source: { type: 1, salt: 0x123 },
+    }),
+  },
+  // Then: your game call
+  {
+    contractAddress: GAME_CONTRACT,
+    entrypoint: 'roll_dice',
+    // ...
+  },
+]);
+```
+
+The `source` in `request_random` must match the `source` in `consume_random`.
+
+## Controller Policy
+
+Add the vRNG contract to your Controller policies:
+
+```typescript
+const policies: Policy[] = [
+  // ... your existing policies ...
+  {
+    target: VRF_PROVIDER_ADDRESS,
+    method: "request_random",
+    description: "Allows requesting random numbers from the VRF provider",
+  },
+];
+```
+
+## Security
+
+Phase 0 assumes the Provider has not revealed the private key and does not collude with players.
+Future plans include moving the Provider to a Trusted Execution Environment (TEE).


### PR DESCRIPTION
Add a comprehensive set of 6 agent skills for deploying and managing services with Slot.

Each skill covers a major area of the platform: core deployments, scaling, paymasters, teams/billing, RPC endpoints, and vRNG integration. Content is sourced from the Slot documentation with practical CLI commands and configuration examples.

Includes:
- slot-deploy: Katana and Torii deployment lifecycle
- slot-scale: Paid tiers, replicas, multi-region
- slot-paymaster: Gasless transactions and policies
- slot-teams: Team billing and credits
- slot-rpc: RPC authentication and CORS
- slot-vrng: Verifiable randomness integration