### PR TITLE
docs: Add agent install instructions to Controller CLI page

### DIFF
--- a/src/pages/controller/examples/cli.md
+++ b/src/pages/controller/examples/cli.md
@@ -13,6 +13,8 @@ This is useful for scripting, backend automation, and AI agent integration.
 
 ## Installation
 
+For humans or agents, via the command-line:
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/cartridge-gg/controller-cli/main/install.sh | bash
 ```


### PR DESCRIPTION
Clarifies that both humans and agents can use the same install command for the Controller CLI.