### PR TITLE
docs: clarify that preset policies override manually provided policies

### DIFF
--- a/src/pages/controller/configuration.md
+++ b/src/pages/controller/configuration.md
@@ -44,6 +44,11 @@ export type ControllerOptions = {
 };
 ```
 
+:::warning
+When both `preset` and `policies` are provided, **preset policies take precedence** by default.
+Manually provided policies are ignored unless you set `shouldOverridePresetPolicies: true`.
+:::
+
 ## Chain Configuration
 
 Controller provides default Cartridge RPC endpoints for Starknet mainnet and sepolia networks:

--- a/src/pages/controller/presets.md
+++ b/src/pages/controller/presets.md
@@ -67,6 +67,11 @@ See an example pull request [`here`](https://github.com/cartridge-gg/presets/pul
 Session Policies can be provided in the preset configuration, providing a smoother experience for your users.
 In order to submit verified policies, create a commit with them to your applications `config.json` in [`@cartridge/presets`](https://github.com/cartridge-gg/presets/tree/main/configs).
 
+:::warning
+When a `preset` is configured, its policies **take precedence** over any `policies` passed directly to the Controller.
+To use manually provided policies instead, set `shouldOverridePresetPolicies: true`.
+:::
+
 For an example, see [dope-wars](https://github.com/cartridge-gg/presets/blob/main/configs/dope-wars/config.json):
 
 ```json


### PR DESCRIPTION
Add warning callouts to both the Configuration and Presets pages explaining that when both preset and policies are provided, preset policies take precedence by default. Users can set shouldOverridePresetPolicies: true to change this behavior.