### PR TITLE
docs: clarify React Native guide flow and architecture

### DIFF
--- a/src/pages/controller/native/react-native.md
+++ b/src/pages/controller/native/react-native.md
@@ -9,6 +9,14 @@ description: Integrate Cartridge Controller into React Native applications using
 Controller can be integrated into React Native applications using TurboModules and the Controller.c FFI bindings.
 This enables session-based authentication and transaction execution in cross-platform mobile apps.
 
+:::info
+This guide uses the native Controller.c bindings to implement the [session flow](/controller/native/session-flow) directly.
+This is the native equivalent of [SessionProvider](/controller/getting-started#sessionprovider-redirect-based) — it generates a local session keypair, authenticates via browser, and executes transactions with the session key.
+It is **not** the [headless controller](/controller/native/headless) pattern, which uses application-managed owner keys without any browser authentication.
+
+If you are wrapping an existing web app for mobile distribution, consider [Capacitor](/controller/native/capacitor) instead, which uses the JS `SessionProvider` directly.
+:::
+
 ## Prerequisites
 
 - Node.js >= 20


### PR DESCRIPTION
## Summary
Add explicit clarification to the React Native integration guide explaining which authentication flow it implements and how it relates to other Controller patterns.

The guide now clearly states that it uses the native session flow (equivalent to SessionProvider), not the headless controller pattern, with links to relevant conceptual docs and the Capacitor alternative for web app wrappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)