### PR TITLE
docs: Update documentation for controller PR #2424

### DIFF
--- a/src/pages/controller/native/capacitor.md
+++ b/src/pages/controller/native/capacitor.md
@@ -112,6 +112,7 @@ const provider = new SessionProvider({
   chainId: constants.StarknetChainId.SN_SEPOLIA,
   redirectUrl: "myapp://session",        // Custom URL scheme
   policies,
+  keychainUrl: "https://x.cartridge.gg", // Optional: customize keychain URL
 });
 ```
 
@@ -260,6 +261,24 @@ const isNative = platform === "ios" || platform === "android";
 const isIOS = platform === "ios";
 const isAndroid = platform === "android";
 ```
+
+## Configuration Options
+
+### Custom Keychain URL
+
+You can customize the keychain URL using the `keychainUrl` parameter or environment variable:
+
+```typescript
+const provider = new SessionProvider({
+  // ... other config
+  keychainUrl: process.env.VITE_KEYCHAIN_URL || "https://x.cartridge.gg",
+});
+```
+
+This is useful for:
+- Testing with development keychain instances
+- Enterprise deployments with custom keychain servers
+- Local development with different keychain configurations
 
 ## Additional Native Features
 


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2424

    **Original PR Details:**
    - Title: test: add capacitor session redirect E2E tests
    - Files changed: .github/workflows/e2e.yml
examples/capacitor/.gitignore
examples/capacitor/package.json
examples/capacitor/playwright.config.ts
examples/capacitor/src/main.ts
examples/capacitor/tests/helpers/webauthn.ts
examples/capacitor/tests/session-redirect.spec.ts
examples/capacitor/vite.config.ts
pnpm-lock.yaml

    Please review the documentation changes to ensure they accurately reflect the controller updates.