### PR TITLE
docs: Update documentation for controller PR #2440

### DIFF
--- a/src/pages/controller/sessions.md
+++ b/src/pages/controller/sessions.md
@@ -94,6 +94,24 @@ export type SessionOptions = {
 };
 ```
 
+### Updating Session Policies
+
+The `updateSession()` method allows you to update session policies at runtime without requiring a full reconnect. This is useful when you need to add new permissions during gameplay or change policy configurations dynamically.
+
+```typescript
+// Update using a preset
+await controller.updateSession({
+  preset: "loot-survivor",
+});
+
+// Update using direct policies
+await controller.updateSession({
+  policies: newSessionPolicies,
+});
+```
+
+Either `policies` or `preset` must be provided. The method opens the keychain interface where users can approve the updated policies, following the same approval flow as initial session creation.
+
 ### Using Presets with SessionProvider
 
 The `preset` parameter allows you to use verified session policies from `@cartridge/presets` instead of manually defining policies. This ensures consistency between SessionProvider and ControllerProvider and simplifies configuration for games with verified presets.


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2440

    **Original PR Details:**
    - Title: feat: add updateSession API for runtime session policy updates
    - Files changed: examples/next/src/app/page.tsx
examples/next/src/components/UpdateSession.tsx
packages/controller/src/controller.ts
packages/controller/src/types.ts
packages/keychain/src/components/UpdateSessionRoute.tsx
packages/keychain/src/components/app.tsx
packages/keychain/src/utils/connection/index.ts
packages/keychain/src/utils/connection/update-session.ts

    Please review the documentation changes to ensure they accurately reflect the controller updates.