### PR TITLE
docs: Update documentation for controller PR #2452

### DIFF
--- a/src/pages/controller/native/session-flow.md
+++ b/src/pages/controller/native/session-flow.md
@@ -32,6 +32,7 @@ https://x.cartridge.gg/session?public_key={public_key}&preset={preset}&rpc_url={
 | `redirect_query_name` | No | Query parameter name for the redirect |
 | `callback_uri` | No | URL to POST session data after creation |
 | `account` | No | Username to prefill and lock during authentication. Forces logout if user is logged in with a different account |
+| `expires_at` | No | Unix timestamp (seconds) to override session expiration. When provided, this value is used instead of the duration picker |
 
 ## Policy Structure
 


### PR DESCRIPTION
This PR updates the documentation to reflect changes made in cartridge-gg/controller#2452

    **Original PR Details:**
    - Title: feat: accept expires_at param on session page
    - Files changed: packages/keychain/src/components/connect/CreateSession.tsx
packages/keychain/src/components/connect/RegisterSession.tsx
packages/keychain/src/components/session.tsx

    Please review the documentation changes to ensure they accurately reflect the controller updates.