### PR TITLE
fix: run link repair before build to prevent dead link failures

### DIFF
--- a/.github/workflows/defrag-docs.yaml
+++ b/.github/workflows/defrag-docs.yaml
@@ -75,13 +75,7 @@ jobs:
                   fi
 
             # ---------------------------------------------------------------
-            # Build (required for phase 3 link validation)
-            # ---------------------------------------------------------------
-            - name: Build site
-              run: pnpm run build
-
-            # ---------------------------------------------------------------
-            # Phase 3: Link repair (validated against build output)
+            # Phase 3: Link repair (source-validated, no build needed)
             # ---------------------------------------------------------------
             - name: "Phase 3: Fix links"
               run: node scripts/fix-links.mjs 2>&1 | tee links-output.txt
@@ -92,7 +86,7 @@ jobs:
                     git add src/pages/
                     git commit -m "chore(defrag): phase 3 — link repair
 
-                  Auto-fixed broken internal links validated against build output.
+                  Auto-fixed broken internal links validated against source files.
                   Extension removals, path corrections, broken anchor cleanup.
 
                   $(tail -15 links-output.txt)"
@@ -101,9 +95,9 @@ jobs:
                   fi
 
             # ---------------------------------------------------------------
-            # Verify build after link fixes
+            # Verify build after all phases
             # ---------------------------------------------------------------
-            - name: Verify build
+            - name: Build site
               run: pnpm run build
 
             # ---------------------------------------------------------------
@@ -156,9 +150,9 @@ jobs:
                   \`\`\`
                   </details>
 
-                  ### Phase 3: Link repair (build-verified)
-                  Auto-fixes broken internal links by validating against the built HTML output.
-                  Fixes extension removal (.md/.mdx), path corrections, and broken anchors.
+                  ### Phase 3: Link repair (source-validated)
+                  Auto-fixes broken internal links by validating against source files.
+                  Fixes extension removal (.md/.mdx), path corrections, and broken relative links.
                   **Reviewers can skim this commit.**
 
                   <details><summary>Phase 3 summary</summary>

--- a/scripts/fix-links.mjs
+++ b/scripts/fix-links.mjs
@@ -1,14 +1,16 @@
 #!/usr/bin/env node
 
 /**
- * Phase 3: Link repair with build verification.
+ * Phase 3: Link repair.
  *
  * 1. Scan all markdown/mdx source files for internal links
- * 2. Validate each link against the build output (src/dist/)
+ * 2. Validate each link against known pages
  * 3. For broken links, attempt to find the correct target
  * 4. Also resolve [TODO: link to X] markers left by phase 2
  *
- * Requires a build to have been run first (pnpm build).
+ * Supports two modes:
+ * - With build output (src/dist/): validates pages and anchors
+ * - Without build output: validates pages from source files (skips anchor checks)
  *
  * Usage:
  *   node scripts/fix-links.mjs
@@ -87,6 +89,24 @@ function buildSourcePageMap(files) {
         map.set(pagePath, f);
     }
     return map;
+}
+
+function buildPagesFromSource(files) {
+    const pages = new Map();
+    for (const f of files) {
+        const pagePath = "/" + f.rel.replace(/\.(md|mdx)$/, "").replace(/\/index$/, "");
+        // Extract heading anchors from markdown (## Heading → "heading")
+        const content = readFileSync(f.path, "utf-8");
+        const anchors = new Set();
+        for (const line of content.split("\n")) {
+            const m = line.match(/^#{1,6}\s+(.+)/);
+            if (m) {
+                anchors.add(m[1].toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, ""));
+            }
+        }
+        pages.set(pagePath, anchors);
+    }
+    return pages;
 }
 
 // ---------------------------------------------------------------------------
@@ -285,19 +305,20 @@ function main() {
     console.log(`Mode: ${DRY_RUN ? "DRY RUN" : "LIVE"}`);
     console.log();
 
-    // Check build output exists
-    if (!existsSync(DIST_DIR)) {
-        console.error("Error: Build output not found at src/dist/. Run 'pnpm build' first.");
-        process.exit(1);
-    }
-
-    // Collect valid pages from build
-    const pages = collectDistPages(DIST_DIR);
-    console.log(`Found ${pages.size} pages in build output`);
-
     // Collect source files
     const sourceFiles = collectDocFiles(DOCS_DIR);
     console.log(`Found ${sourceFiles.length} source files`);
+
+    // Use build output if available, otherwise fall back to source files
+    let pages;
+    if (existsSync(DIST_DIR)) {
+        pages = collectDistPages(DIST_DIR);
+        console.log(`Found ${pages.size} pages in build output`);
+    } else {
+        console.log("No build output found — validating against source files (anchor checks may be approximate)");
+        pages = buildPagesFromSource(sourceFiles);
+        console.log(`Found ${pages.size} pages from source files`);
+    }
     console.log();
 
     let totalBroken = 0;


### PR DESCRIPTION
## Summary
- Phase 2 (LLM content defrag) can introduce broken relative links (e.g. `./configuration` from `controller/examples/`), which causes the vocs build to fail on dead links before Phase 3 (link repair) ever runs.
- `fix-links.mjs` now falls back to source-file validation when no build output exists, deriving the page map and heading anchors directly from `.md`/`.mdx` files.
- The workflow now runs fix-links **before** the build, eliminating the chicken-and-egg problem. A single build at the end verifies everything.

## Test plan
- [ ] Trigger a manual `workflow_dispatch` run of the defrag workflow
- [ ] Verify Phase 3 runs successfully without build output
- [ ] Verify the final build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)