### PR TITLE
fix: fix-links regex to handle .mdx extensions correctly

### DIFF
--- a/scripts/fix-links.mjs
+++ b/scripts/fix-links.mjs
@@ -216,7 +216,7 @@ function resolveRelative(base, rel) {
 function suggestFix(result, url, pages) {
     if (result.reason === "has extension") {
         // Just strip the extension
-        return url.replace(/\.(md|mdx)/, "");
+        return url.replace(/\.(mdx|md)$/, "");
     }
 
     if (result.reason === "anchor not found" && result.path) {

--- a/src/pages/controller/starter-packs.md
+++ b/src/pages/controller/starter-packs.md
@@ -248,13 +248,13 @@ Credits purchased through this interface use the same unified payment flow as st
 
 If you encounter issues with purchase integration:
 - Check the browser console for detailed error messages
-- Verify your Controller setup matches the [getting started guide](/controller/getting-started.mdx)
+- Verify your Controller setup matches the [getting started guide](/controller/getting-started)
 - Ensure you're using the latest version of the Controller SDK
-- Review [external wallet setup](/controller/signer-management.md) for wallet-related issues
+- Review [external wallet setup](/controller/signer-management) for wallet-related issues
 
 ## Next Steps
 
-- Learn about [Session Keys](/controller/sessions.md) for gasless gaming experiences
-- Explore [Controller Configuration](/controller/configuration.md) options
-- Set up [External Wallet Integration](/controller/signer-management.md)
-- Review [Paymaster Configuration](/slot/paymaster.md) for gasless transactions
+- Learn about [Session Keys](/controller/sessions) for gasless gaming experiences
+- Explore [Controller Configuration](/controller/configuration) options
+- Set up [External Wallet Integration](/controller/signer-management)
+- Review [Paymaster Configuration](/slot/paymaster) for gasless transactions


### PR DESCRIPTION
## Problem
The defrag script's link repair phase was creating broken links when fixing `.mdx` files. The regex in `suggestFix` was missing the `$` anchor and checked `.md` before `.mdx`, causing it to match `.md` within `.mdx` filenames.

Example: `/controller/getting-started.mdx` → `/controller/getting-startedx` ❌

## Solution
- Fixed regex in `scripts/fix-links.mjs` line 219: `/\.(md|mdx)/` → `/\.(mdx|md)$/`
- Removed file extensions from existing links in `starter-packs.md` to prevent future repair issues

## Build Status
- Local build passes with no dead link errors
- Ready for next defrag run

## Changes
- `scripts/fix-links.mjs`: Fix extension stripping regex
- `src/pages/controller/starter-packs.md`: Remove extensions from 6 internal links