### PR TITLE
chore: upgrade Node.js to 24 and improve emphasis rules

### DIFF
--- a/.github/workflows/defrag-docs.yaml
+++ b/.github/workflows/defrag-docs.yaml
@@ -16,7 +16,7 @@ jobs:
             - name: Set up Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: "22"
+                  node-version: "24"
 
             - name: Set up pnpm
               uses: pnpm/action-setup@v4

--- a/scripts/defrag-docs.mjs
+++ b/scripts/defrag-docs.mjs
@@ -179,7 +179,8 @@ ${styleGuide ? `## Style guide\n\n${styleGuide}\n\n` : ""}## Rules
 - When the report says to replace duplicated content with a cross-reference, use a brief mention with a markdown link to the canonical page. Use [TODO: link to X] if you cannot verify the target.
 - Do not add or change links unless the report specifically recommends it and you can verify the target path exists in the file listing. When uncertain, use [TODO: link to X].
 - If the file needs no changes, return it exactly as-is.
-- Preserve the original voice and technical accuracy.`;
+- Preserve the original voice and technical accuracy.
+- Use single asterisks for italics and double asterisks for bold. Do not use underscores for emphasis.`;
 
 function buildEditPrompt(report, file, allFiles) {
     const content = loadTextFile(file.path);


### PR DESCRIPTION
Upgrades Node.js from 22 to 24 in the defrag-docs workflow and adds an emphasis formatting rule to the LLM system prompt to ensure consistent markdown formatting (single asterisks for italics, double for bold, no underscores).

Both changes improve consistency and future-proof the CI environment.