### PR TITLE
docs: collapse vRNG sidebar section by default

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -253,6 +253,7 @@ export default defineConfig({
           },
           {
             text: "vRNG",
+            collapsed: true,
             items: [
               {
                 text: "Overview",


### PR DESCRIPTION
## Summary

- Sets the vRNG sidebar group to `collapsed: true` so it starts closed and doesn't clutter the Slot sidebar.

## Test plan

- [ ] Verify vRNG section renders collapsed in the sidebar and expands on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)